### PR TITLE
fixed resizer css in grid 

### DIFF
--- a/css/less/src/w2ui-grid.less
+++ b/css/less/src/w2ui-grid.less
@@ -139,6 +139,7 @@ div.w2ui-grid {
 
 			.w2ui-resizer {
 				position: absolute; 
+				display:block;
 				padding: 0px; 
 				margin: 0px;
 				width: 5px; 


### PR DESCRIPTION
when w2grid create in w2layout

applied .w2layout .w2ui-resizer class that default display is "display:none" 

so change "display:block"
