### PR TITLE
fixed remove node in sidebar 

### DIFF
--- a/src/w2sidebar.js
+++ b/src/w2sidebar.js
@@ -183,7 +183,7 @@
 				tmp.parent.nodes.splice(ind, 1);
 				deleted++;
 			}
-			if (arguments.length == 1) this.refresh(arguments[0]); else this.refresh();
+			if (deleted > 0 && arguments.length == 1) this.refresh(tmp.parent.id); else this.refresh();
 			return deleted;
 		},
 		


### PR DESCRIPTION
when argument.length is 1, arguments[0] is already deleted node id. 
changed to tmp.parent.id
