### PR TITLE
refactored cross() to use feature detection rather than $.browser.webkit

### DIFF
--- a/src/w2utils.js
+++ b/src/w2utils.js
@@ -566,7 +566,8 @@ var w2utils = (function () {
 		}, time * 1000);
 		
 		function cross(property, value, none_webkit_value) {
-			if (!$.browser.webkit && typeof none_webkit_value != 'undefined') value = none_webkit_value;
+			var isWebkit=!!window.webkitURL; // jQuery no longer supports $.browser - RR
+			if (!isWebkit && typeof none_webkit_value != 'undefined') value = none_webkit_value;
 			return ';'+ property +': '+ value +'; -webkit-'+ property +': '+ value +'; -moz-'+ property +': '+ value +'; '+
 				   '-ms-'+ property +': '+ value +'; -o-'+ property +': '+ value +';';
 		}


### PR DESCRIPTION
Hit an error playing with popups and jQuery-1.9.1 where w2utils:cross() failed with a null reference to $.browser.

Since jQuery no longer supports $.browser (deprecated 1.3, removed 1.9), refactored cross() to use feature detection instead.
