### PR TITLE
Fix a bug when the grid is hidden

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -3046,7 +3046,7 @@
 			var time = (new Date()).getTime();
 			var obj  = this;
 			var records	= $('#grid_'+ this.name +'_records');
-			if (this.records.length == 0) return;
+			if (this.records.length == 0 || records.height()==0) return;
 			if (this.buffered > 300) this.show_extra = 30; else this.show_extra = 300; 
 			// need this to enable scrolling when this.limit < then a screen can fit
 			if (records.height() < this.buffered * this.recordHeight && records.css('overflow-y') == 'hidden') {


### PR DESCRIPTION
When the grid is hidden, for instance in a hidden div, the scroll and
the refresh function are inducing an infinite loop that is consuming
alle the ressources of the computer.
This fixes this bug...
