### PR TITLE
w2layout: correct panel size calculation

### DIFF
--- a/src/w2layout.js
+++ b/src/w2layout.js
@@ -404,10 +404,10 @@
 				ptop.size = height * parseInt(ptop.size) / 100;
 			}
 			if (pleft && String(pleft.size).substr((String(pleft.size).length-1)) == '%') {
-				pleft.size = height * parseInt(pleft.size) / 100;
+				pleft.size = width * parseInt(pleft.size) / 100;
 			}
 			if (pright && String(pright.size).substr((String(pright.size).length-1)) == '%') {
-				pright.size = height * parseInt(pright.size) / 100;
+				pright.size = width * parseInt(pright.size) / 100;
 			}
 			if (pbottom && String(pbottom.size).substr((String(pbottom.size).length-1)) == '%') {
 				pbottom.size = height * parseInt(pbottom.size) / 100;


### PR DESCRIPTION
Calculate %-sizes of vertical panels ('left' and 'right') as percentage of the layout's width, not height.
Otherwise, you get some strange results if specifiyng those panel's size in percent...
