### PR TITLE
w2grid: doSave() failed to trigger event after saving to remote data source

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -1096,9 +1096,10 @@
 			var eventData = this.trigger({ phase: 'before', target: this.name, type: 'save', changed: changed });
 			if (eventData.stop === true) return false;
 			if (this.url != '') {
+				var $this = this;
 				this.request('save-records', { 'changed' : changed }, null, function () {
 					// event after
-					this.trigger($.extend(eventData, { phase: 'after' }));
+					$this.trigger($.extend(eventData, { phase: 'after' }));
 				});
 			} else {
 				for (var c in changed) {


### PR DESCRIPTION
Inside the callback after completing the remote request, 'this' would point to the window object, thus this.trigger() would give a 'TypeError: this.trigger is not a function'.
I solved this by creating a reference to the 'real' this before the callback.

Just a quick workaround to fix that problem for me.
If you solved similar functionality elsewhere already, feel free to discard this pull request and fix the bug using your own w2ui coding conventions :-)
