### PR TITLE
w2grid: Don't add double break if search field is hidden

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -1689,7 +1689,7 @@
 						this.toolbar.items.push({ type: 'button', id: 'search-advanced', caption: w2utils.lang('Search...'), hint: w2utils.lang('Open Search Fields') });
 					}
 				}
-				if (this.show.toolbarAdd || this.show.toolbarDelete || this.show.toolbarSave) {
+				if (this.show.toolbarSearch && (this.show.toolbarAdd || this.show.toolbarDelete || this.show.toolbarSave)) {
 					this.toolbar.items.push({ type: 'break', id: 'break1' });
 				}
 				if (this.show.toolbarAdd) {


### PR DESCRIPTION
With 
        show: {
            header: true,
            footer: true,
            toolbar: true,
            toolbarSave: true,
            toolbarAdd: true,
            toolbarDelete: true,
            toolbarSearch: false,
        },
there were two toolbar separators between the refresh/show/hide buttons an the add/delete buttons, looking not so nice.
