### PR TITLE
w2grid: add option to *not* mark search results

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -126,6 +126,7 @@
 		this.multiSearch	= true;
 		this.multiSelect	= true;
 		this.multiSort		= true;
+		this.markSearchResults	= true;
 
 		this.total			= 0;		// server total
 		this.buffered		= 0;		// number of records in the records array
@@ -3596,6 +3597,7 @@
 
 			function markSearch() {
 				// mark search
+				if(obj.markSearchResults === false) return;
 				clearTimeout(obj.last.marker_timer);
 				obj.last.marker_timer = setTimeout(function () {
 					// mark all search strings


### PR DESCRIPTION
Marking search results is a nice feature for textual data, but when filtering your records for numerical data it is very annoying to e.g. have all 2's marked in every other column, too.

This proposal adds the option `markSearchResults` to w2grid. It defaults to `true`, so the default behaviour does not change.
