### PR TITLE
Toolbar: Correctly handle spacer when inserted on runtime

### DIFF
--- a/src/w2toolbar.js
+++ b/src/w2toolbar.js
@@ -302,9 +302,13 @@
 			var html  = this.getItemHTML(it);
 			if (el.length == 0) {
 				// does not exist - create it
-				html =  '<td id="tb_'+ this.name + '_item_'+ it.id +'" style="'+ (it.hidden ? 'display: none' : '') +'" '+
+				if (it.type == 'spacer') {
+					html = '<td width="100%" id="tb_'+ this.name +'_item_'+ it.id +'" align="right"></td>';
+				} else {
+					html =  '<td id="tb_'+ this.name + '_item_'+ it.id +'" style="'+ (it.hidden ? 'display: none' : '') +'" '+
 						'	class="'+ (it.disabled ? 'disabled' : '') +'" valign="middle">'+ html + 
 						'</td>';
+				}
 				if (this.get(id, true) == this.items.length-1) {
 					$(this.box).find('#tb_'+ this.name +'_right').before(html);
 				} else {


### PR DESCRIPTION
When inserting a spacer into a toolbar with toolbar.add() or toolbar.insert(), the html code is generated by the refresh() method instead of render().
I copied the `if (it.type == 'spacer')` exception from render() to refresh() in order to correctly handle spacer inserts.

Still, because of how the refresh() method works, you need to supply an id for the spacer if using add() or insert() to create it.
