### PR TITLE
fixed bug in chrome

### DIFF
--- a/src/w2form.js
+++ b/src/w2form.js
@@ -631,10 +631,15 @@
 			var page	= $(this.box).find('> div .w2ui-page');
 			var cpage	= $(this.box).find('> div .w2ui-page.page-'+ this.page);
 			var dpage	= $(this.box).find('> div .w2ui-page.page-'+ this.page + ' > div');
-			var buttons	= $(this.box).find('> div .w2ui-buttons');		
+			var buttons	= $(this.box).find('> div .w2ui-buttons');
+			var box_height;
+		
 			// if no height, calculate it
 			resizeElements();
-			if ($(this.box).height() == 0 || $(this.box).data('auto-size') === true) {
+			box_height = $(this.box).height();
+			box_height = ( box_height - box_height % 1);
+
+			if ( box_height == 0 || $(this.box).data('auto-size') === true) {
 				$(this.box).height(
 					(header.length > 0 ? w2utils.getSize(header, 'height') : 0) + 
 					(this.tabs.tabs.length > 0 ? w2utils.getSize(tabs, 'height') : 0) + 


### PR DESCRIPTION
when you don't specify an height to the form, in chrome it will not
resize and show a thin bar (2 pixels).
This is due to the abolute positioning needing to recalculate the
height.
In chrome the jquery height function give a flaot number (-0,22…) in
this case.
I just rounded the result of the jquery height function (jquery 1.10).
