### PR TITLE
Small typo fix in docs    resizeTo --> sizeTo

### DIFF
--- a/docs/details/w2layout.sizeTo.html
+++ b/docs/details/w2layout.sizeTo.html
@@ -40,10 +40,11 @@ $('#layout').w2layout({
 	panels  : [
 		{ type: 'top', size: 40 },
 		{ type: 'main', content: 'This is main panel' },
-		{ type: 'preview', size: 200, hidden: true }
+		{ type: 'preview', size: 200, hidden: true },
+		{ type: 'right', size: 40 }
 	]
 });
 
-w2ui['layout'].resizeTo('right', 100);
+w2ui['layout'].sizeTo('right', 100);
 </textarea>
 


### PR DESCRIPTION
I spotted two typos while reading the docs. 
