### PR TITLE
Fixed html input type for password fields

### DIFF
--- a/src/w2form.js
+++ b/src/w2form.js
@@ -524,6 +524,9 @@
 				if (field.html.caption == '') field.html.caption = field.name;
 				var input = '<input name="'+ field.name +'" type="text" '+ field.html.attr +'/>';
 				// if (field.type == 'list') input = '<select name="'+ field.name +'" '+ field.html.attr +'></select>';
+                if ((field.type === 'pass') || (field.type === 'password')){
+                    input = '<input name="' + field.name + '" type = "password" ' + field.html.attr + '/>';
+                }
 				if (field.type == 'checkbox') input = '<input name="'+ field.name +'" type="checkbox" '+ field.html.attr +'/>';
 				if (field.type == 'textarea') input = '<textarea name="'+ field.name +'" '+ field.html.attr +'></textarea>';
 				html += '\n   <div class="w2ui-label '+ (typeof field.html.span != 'undefined' ? 'w2ui-span'+ field.html.span : '') +'">'+ field.html.caption +':</div>'+


### PR DESCRIPTION
Before i write:

<pre><code type="javascript">var loginForm = $().w2form({
    name: "LoginForm",
    url: "/auth",
    fields: [
        {name: "login", type: "text", required: "true", html: {caption: "Логин", span: 3}},
        {name: "pass", type: "password", required: "true", html: {caption: "Пароль", span: 3, attr: "type='password'"}}
    ],
    actions: {
        "Вход": function () {
            console.log("Вход");
        }
    }
});
$("#authform").w2render(loginForm);</code></pre>

In html code i see 'input type = "text"', not "password"! My passwords not hided in HTML-forms!
