### PR TITLE
w2fields: fixed bug in color/list/combo/enum fields where clicking on the 'suffix' element ... 

### DIFF
--- a/src/w2fields.js
+++ b/src/w2fields.js
@@ -1359,8 +1359,8 @@
 							'margin-top'		: (parseInt($(obj.el).css('margin-top'), 10) + 1) + 'px',
 							'margin-bottom'		: (parseInt($(obj.el).css('margin-bottom'), 10) + 1) + 'px'
 						})
-						.on('click', function () { 
-							$(obj).prev().focus(); 
+						.on('click', function () {
+							$(obj.el).focus();
 						});
 					helper.css('margin-left', '-'+ (w2utils.getSize(helper, 'width') + parseInt($(obj.el).css('margin-right'), 10) + 2) + 'px');
 					pr += helper.width() + 3;


### PR DESCRIPTION
... (the color/dropdown image at right edge) would not focus the edit element and thus would not forward the click event to onFocus; consequently no color/list/enum dropdown was shown when you clicked on that element.

Expected behaviour has now been restored: click on suffix element pops up the corresponding list/view.
