### PR TITLE
Remove timer when calculating body size

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -3665,7 +3665,7 @@
 			// body might be expanded by data
 			if (!this.fixedBody) {
 				// allow it to render records, then resize
-				setTimeout(function () {
+				//setTimeout(function () {
 					var calculatedHeight = w2utils.getSize(columns, 'height')
 						+ w2utils.getSize($('#grid_'+ obj.name +'_records table'), 'height');
 					obj.height = calculatedHeight
@@ -3677,7 +3677,7 @@
 					grid.css('height', obj.height);
 					body.css('height', calculatedHeight);
 					box.css('height', w2utils.getSize(grid, 'height') + w2utils.getSize(box, '+height'));
-				}, 1);
+				//}, 1);
 			} else {
 				// fixed body height
 				var calculatedHeight =  grid.height()


### PR DESCRIPTION
When grid fixedBody property is false. the selection mechanisme do not work properly, I reproduce the same behavior in demo
http://w2ui.com/web/demos/#!grid/grid-11 I removed setTimeout, and that corrected the problem.
