### PR TITLE
prevent search popup from closing when clicking on drop down arrow

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -1863,12 +1863,10 @@
 			}
 			// refresh cell
 			var cell = this.getCellHTML(index, column, summary);
-			if (!summary) {
-				if (rec.changes && typeof rec.changes[col.field] != 'undefined') {
-					$(tr).find('[col='+ column +']').addClass('w2ui-changed').html(cell);
-				} else {
-					$(tr).find('[col='+ column +']').removeClass('w2ui-changed').html(cell);
-				}
+			if (!summary &&rec.changes && typeof rec.changes[col.field] != 'undefined') {
+				$(tr).find('[col='+ column +']').addClass('w2ui-changed').html(cell);
+			} else {
+				$(tr).find('[col='+ column +']').removeClass('w2ui-changed').html(cell);
 			}
 		},
 


### PR DESCRIPTION
Error behaviour:
- open search dialog
- click on drop down arrow for, e.g., operator
- click on drop down arrow again, while items are displayed
- search dialog closes
