### PR TITLE
Very last record expansion is removed when scrolling

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -4291,7 +4291,7 @@
 			var tr2 = records.find('#grid_'+ this.name +'_rec_bottom');
 			// if row is expanded
 			if (String(tr1.next().prop('id')).indexOf('_expanded_row') != -1) tr1.next().remove();
-			if (String(tr2.prev().prop('id')).indexOf('_expanded_row') != -1) tr2.prev().remove();
+			if (this.total > end && String(tr2.prev().prop('id')).indexOf('_expanded_row') != -1) tr2.prev().remove();
 			var first = parseInt(tr1.next().attr('line'));
 			var last  = parseInt(tr2.prev().attr('line'));
 			//$('#log').html('buffer: '+ this.buffered +' start-end: ' + start + '-'+ end + ' ===> first-last: ' + first + '-' + last);


### PR DESCRIPTION
- load some expandable rows via ajax, so that a scrollbar appears
- scroll to the very last record (until no more dynamic loading occurs)
- expand the last record
- it is marked as expanded, but the expansion cannot be seen
- try to scroll it up
- the expansion vanishes, but the expansion marker still shows the record as expanded

This patch is a quick fix, which may need more throught.
