### PR TITLE
w2layout: add the 'load dynamic content' code so we can observe scroll bar show up / disappear + where exactly

### DIFF
--- a/demos/examples/layout-10.html
+++ b/demos/examples/layout-10.html
@@ -1,7 +1,13 @@
 <div class="content">
 	<div id="example_title">
 		<h1>Panel with Title</h1>
+		<p>
 		A layout panel may be created with a title.
+		</p>
+		
+		<p>
+		You can dynamically load content into the main panel; this is done so you can observe the overflow behaviour of the panel (scrollbars).
+		</p>
 	</div>
 	<div id="example_view"></div>
 	<div id="example_code"></div>
@@ -9,6 +15,14 @@
 
 <!--CODE-->
 <div id="layout" style="width: 100%; height: 400px;"></div>
+
+<div style="height: 20px;"></div>
+
+
+<span style="display: inline-block; width: 50px;"> Main: </span>
+<input type="button" value="Set Content" onclick="w2ui['layout'].content('main', 'This is some content set manually')">
+<input type="button" value="Load Content 1" onclick="w2ui['layout'].load('main', 'data/content1.html')">
+<input type="button" value="Load Content 2" onclick="w2ui['layout'].load('main', 'data/content2.html')">
 
 <!--CODE-->
 $(function () {	

--- a/demos/examples/layout-4.html
+++ b/demos/examples/layout-4.html
@@ -27,8 +27,8 @@
 <input type="button" value="Load Content 2" onclick="w2ui['layout'].load('main', 'data/content2.html')">
 
 <!--CODE-->
-$(function () {
-	var pstyle = 'border: 1px solid #dfdfdf; padding: 5px;'
+$(function () {	
+	var pstyle = 'border: 1px solid #dfdfdf; padding: 5px;';
 	$('#layout').w2layout({
 		name: 'layout',
 		panels: [

--- a/demos/examples/layout-8.html
+++ b/demos/examples/layout-8.html
@@ -1,9 +1,15 @@
 <div class="content">
 	<div id="example_title">
 		<h1>Panel with Tabs</h1>
+		<p>
 		A layout panel may be created with tabs. It uses w2tabs object, therefore, you can use anything w2tabs support. There
 		is no need to define a name of the tabs, because it will be overwritten with layout.name + '_tabs'. It will also add tabs.owner
 		attribute that is a reference to the layout.
+		</p>
+		
+		<p>
+		You can dynamically load content into the main panel; this is done so you can observe the overflow behaviour of the panel (scrollbars).
+		</p>
 	</div>
 	<div id="example_view"></div>
 	<div id="example_code"></div>
@@ -11,6 +17,14 @@
 
 <!--CODE-->
 <div id="layout" style="width: 100%; height: 400px;"></div>
+
+<div style="height: 20px;"></div>
+
+
+<span style="display: inline-block; width: 50px;"> Main: </span>
+<input type="button" value="Set Content" onclick="w2ui['layout'].content('main', 'This is some content set manually')">
+<input type="button" value="Load Content 1" onclick="w2ui['layout'].load('main', 'data/content1.html')">
+<input type="button" value="Load Content 2" onclick="w2ui['layout'].load('main', 'data/content2.html')">
 
 <!--CODE-->
 $(function () {	
@@ -20,7 +34,7 @@ $(function () {
 		panels: [
 			{ type: 'top', size: 50, resizable: true, style: pstyle, content: 'top' },
 			{ type: 'left', size: 200, resizable: true, style: pstyle, content: 'left' },
-			{ type: 'main', style: pstyle + 'border-top: 0px;', content: 'tab1', 
+			{ type: 'main', style: pstyle + 'border-top: 0px;', content: 'main', 
 				tabs: {
 					active: 'tab1',
 					tabs: [

--- a/demos/examples/layout-9.html
+++ b/demos/examples/layout-9.html
@@ -1,9 +1,15 @@
 <div class="content">
 	<div id="example_title">
 		<h1>Panel with Toolbar</h1>
+		<p>
 		A layout panel may be created with a toolbar. It uses w2toolbar object, therefore, you can use anything w2toolbar support. There
 		is no need to define a name of the toolbar, because it will be overwritten with layout.name + '_toolbar'. It will also add toolbar.owner
 		attribute that is a reference to the layout.
+		</p>
+		
+		<p>
+		You can dynamically load content into the main panel; this is done so you can observe the overflow behaviour of the panel (scrollbars).
+		</p>
 	</div>
 	<div id="example_view"></div>
 	<div id="example_code"></div>
@@ -11,6 +17,14 @@
 
 <!--CODE-->
 <div id="layout" style="width: 100%; height: 400px;"></div>
+
+<div style="height: 20px;"></div>
+
+
+<span style="display: inline-block; width: 50px;"> Main: </span>
+<input type="button" value="Set Content" onclick="w2ui['layout'].content('main', 'This is some content set manually')">
+<input type="button" value="Load Content 1" onclick="w2ui['layout'].load('main', 'data/content1.html')">
+<input type="button" value="Load Content 2" onclick="w2ui['layout'].load('main', 'data/content2.html')">
 
 <!--CODE-->
 $(function () {	

--- a/demos/index.css
+++ b/demos/index.css
@@ -24,6 +24,10 @@ ul {
 	margin: 10px 0px 10px 40px;
 }
 
+p + p {
+	margin-top: 1em;
+}
+
 #main_layout {
 	position: absolute; 
 	width: 100%; 


### PR DESCRIPTION
cf. commit SHA-1: 9887059b81130195146837b24341ed94c49227b2:
- add the 'load dynamic content' code from layout example 4 to layout examples 8, 9 & 10 (layout with tabs, layout with toolbar, layout with titles) so that we can observe panel overflow behaviour (previously, overflow was applied to the entire panel, i.e. including the title, toolbar and tab-bar! This has been fixed in commit SHA-1: 33202a80a2f47d930af3cb317a8bcb55121c5675)
