### PR TITLE
fixed display error of toolbar button's dropdown mark on non-webkit brow...

### DIFF
--- a/src/less/src/toolbar.less
+++ b/src/less/src/toolbar.less
@@ -46,19 +46,13 @@
 			}
 
 			.w2ui-tb-down {
-				width: 14px;
-				height: 24px;
-				padding: 2px;
+				padding: 3px;
 			}
 
 			.w2ui-tb-down > div {
-				position: absolute;
-				width: 0px;
-				height: 28px;
-				line-height: 100%;
 				border: 4px solid transparent;
 				border-top: 5px solid #8D99A7;
-				margin-top: -2px;
+				margin-top: 5px;
 			}
 
 			&.over {


### PR DESCRIPTION
Fixed display error of toolbar button's dropdown mark on non-webkit browsers (IE, FF, Opera)

Error was that the right border of the buttons overlap with dropdown mark.
