### PR TITLE
Fix position when holding on draggable column

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -3267,8 +3267,10 @@
 					}).addClass( '.w2ui-grid-ghost' ).animate({
 							width: selectedCol.width(),
 							height: $(obj.box).find('.w2ui-grid-body:first').height(),
+							left : event.pageX,
+							top : event.pageY,
 							opacity: .8
-						}, 300 );
+						}, 0 );
 
 					//establish current offsets
 					_dragData.offsets = [];


### PR DESCRIPTION
Set he position of the ghost to the position of the cursor.
Also change the animation duration to 0, so the ghost appear in the correct position without animation from the top of the screen.
