### PR TITLE
Fix spurious prefix/suffix helpers

### DIFF
--- a/src/w2fields.js
+++ b/src/w2fields.js
@@ -432,6 +432,7 @@
 			var obj		= this;
 			var options	= this.options;
 			var tmp 	= $(this.el).data('tmp');
+			this.type 	 = 'clear';
 			if (!this.tmp) return;
 			// restore paddings
 			if (typeof tmp != 'undefined') {
@@ -466,7 +467,6 @@
 			// remove helpers
 			for (var h in this.helpers) $(this.helpers[h]).remove();
 			this.helpers = {};
-			this.type 	 = 'clear';
 		},
 
 		refresh: function () {
@@ -1502,6 +1502,7 @@
 		addPrefix: function () {
 			var obj = this;
 			setTimeout(function () {
+				if (obj.type === 'clear') return;
 				var helper;
 				var tmp = $(obj.el).data('tmp') || {};
 				if (tmp['old-padding-left']) $(obj.el).css('padding-left', tmp['old-padding-left']);
@@ -1560,6 +1561,7 @@
 			var obj = this;
 			var helper, pr;
 			setTimeout(function () {
+				if (obj.type === 'clear') return;
 				var tmp = $(obj.el).data('tmp') || {};
 				if (tmp['old-padding-right']) $(obj.el).css('padding-right', tmp['old-padding-right']);
 				tmp['old-padding-right'] = $(obj.el).css('padding-right');


### PR DESCRIPTION
I see, that you have been struggling with this before :)
I can still get a couple of additional down-arrow suffixes for list fields on multi-tab forms.
(See http://sw-amt.ws/w2ui/demos/#!grid/grid-31 or http://jsfiddle.net/rYL5F/13/).

This is the last fix I need for my first real-life production application
employing w2ui. Everything else works out of the box now. (If you are
interested, you can see it at http://sw-amt.ws/trade_cat/ for a while).

Thanks for your great effort!
