### PR TITLE
w2ui-search-all placholder centered vertically

### DIFF
--- a/src/less/src/grid.less
+++ b/src/less/src/grid.less
@@ -55,7 +55,7 @@
 			outline: none !important;
 			width: 160px;
 			border-radius: 10px;
-			line-height: 100%;
+			line-height: normal;
 			height: 22px;
 			border: @grid-search-all-border;
 			color: @grid-search-all-color;


### PR DESCRIPTION
.w2ui-search-all for 'placholder' in chrome was not centered vertically
