### PR TITLE
.locale() added cleaning phrases of old language

### DIFF
--- a/src/w2utils.js
+++ b/src/w2utils.js
@@ -816,6 +816,10 @@ var w2utils = (function () {
     function locale (locale) {
         if (!locale) locale = 'en-us';
         if (locale.length === 5) locale = 'locale/'+ locale +'.json';
+        
+        // clear phrases from language before
+        w2utils.settings.phrases = {};
+
         // load from the file
         $.ajax({
             url      : locale,


### PR DESCRIPTION
when changing lang from other language to English -> must clean
