### PR TITLE
 problem with decimal/groupSeparator in italian #647

### DIFF
--- a/src/w2fields.js
+++ b/src/w2fields.js
@@ -737,10 +737,12 @@
             val = String(val).trim();
             // clean
             if (['int', 'float', 'money', 'currency', 'percent'].indexOf(this.type) != -1) {
-                if (typeof val == 'string') val = val.replace(options.decimalSymbol, '.');
-                if (options.autoFormat && ['money', 'currency'].indexOf(this.type) != -1) val = String(val).replace(options.moneyRE, '');
-                if (options.autoFormat && this.type == 'percent') val = String(val).replace(options.percentRE, '');
-                if (options.autoFormat && ['int', 'float'].indexOf(this.type) != -1) val = String(val).replace(options.numberRE, '');
+                if (typeof val == 'string') {
+                    if (options.autoFormat && ['money', 'currency'].indexOf(this.type) != -1) val = String(val).replace(options.moneyRE, '');
+                    if (options.autoFormat && this.type == 'percent') val = String(val).replace(options.percentRE, '');
+                    if (options.autoFormat && ['int', 'float'].indexOf(this.type) != -1) val = String(val).replace(options.numberRE, '');
+                    val = val.replace(options.decimalSymbol, '.');
+                }
                 if (parseFloat(val) == val) {
                     if (options.min !== null && val < options.min) { val = options.min; $(this.el).val(options.min); }
                     if (options.max !== null && val > options.max) { val = options.max; $(this.el).val(options.max); }


### PR DESCRIPTION
In italian we have:
"groupSymbol" : ".",
"decimalSymbol" : ",",
the opposite of english, and, in the funciont clean of w2fields,
we have the wrong order of replace for example:
if val == '123,45' that in invarant form is equal to 123.45 the function
clean first replace decimalSeparator with '.' so I have -> '123.45' and
after replace groupSeparator with '', but in italian the groupSeparator
is '.' and I have -> '12345'.
My solution is the following:
that first eliminate the groupSeparator and after replace
decimalSeparator.
