### PR TITLE
For older browser (or WebBrowserControl, ...)

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -2203,7 +2203,7 @@
                     msg   : obj.msgDelete, 
                     yes_class : 'btn-red',
                     callBack: function (result) {
-                        if (result == 'Yes') w2ui[obj.name].delete(true);
+                        if (result == 'Yes') w2ui[obj.name]['delete'](true);
                     }
                 });
                 return;


### PR DESCRIPTION
Some older js see delete ONLY as KEYWORD and consider an error the use
of this key. Can be resolved with my change.
It's the only instance in w2ui.
