### PR TITLE
Per record edit type support

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -2026,12 +2026,30 @@
             }
         },
 
+
+        getEdit: function(column, record){
+            if(!$.isPlainObject(record)){
+                record = this.get(record);
+            }
+            if(column && column.editable){
+               var edit = column.editable;
+               if(typeof edit === 'function'){
+                   return edit(record);
+               } else {
+                   return edit;
+               }
+            } else {
+               return null;
+            }
+        },
+
         editField: function (recid, column, value, event) {
             var obj   = this;
             var index = obj.get(recid, true);
             var rec   = obj.records[index];
             var col   = obj.columns[column];
-            var edit  = col ? col.editable : null;
+            var edit  = this.getEdit(col, rec);
+
             if (!rec || !col || !edit || rec.editable === false) return;
             if (['enum', 'file'].indexOf(edit.type) != -1) {
                 console.log('ERROR: input types "enum" and "file" are not supported in inline editing.');
@@ -2927,7 +2945,8 @@
             // default action
             this.selectNone();
             var col = this.columns[column];
-            if (col && $.isPlainObject(col.editable)) {
+            var edit = this.getEdit(col, recid);
+            if (col && $.isPlainObject(edit)) {
                 this.editField(recid, column, null, event);
             } else {
                 this.select({ recid: recid, column: column });
@@ -5359,7 +5378,7 @@
             var col    = this.columns[col_ind];
             var record = (summary !== true ? this.records[ind] : this.summary[ind]);
             var data   = this.getCellValue(ind, col_ind, summary);
-            var edit   = col.editable;
+            var edit  = this.getEdit(col, record);
             // various renderers
             if (typeof col.render != 'undefined') {
                 if (typeof col.render == 'function') {

--- a/test/grid2.html
+++ b/test/grid2.html
@@ -21,6 +21,56 @@ $(function () {
         { id: 8, text: 'Nicolas Cage' },
     ];
 
+    var editFunc = function(record) {
+        return record.funcType;
+    };
+
+    var funcTypes = [
+        { type: 'int', min: 0, max: 100 },
+        { type: 'money' },
+        { type: 'percent' },
+        { type: 'hex' },
+        { type: 'color' },
+        { type: 'date' },
+        { type: 'time' },
+        { type: 'list', items: people },
+        { type: 'checkbox' }
+    ];
+
+    var getFuncType = function(index) {
+        if(index >= funcTypes.length){
+            return funcTypes[funcTypes.length - 1];
+        } else {
+            return funcTypes[index];
+        }
+    };
+
+    var getFuncValue = function(index) {
+        var funcType = getFuncType(index);
+        switch(funcType.type) {
+            case 'int':
+                return 5;
+            case 'money':
+                return  6;
+            case 'percent':
+                return 7;
+            case 'hex':
+                return 0x2;
+            case 'color':
+                return  0xffffff;
+            case 'date':
+                return new Date();
+            case 'time':
+                return new Date();
+            case 'list':
+                return 3;
+            case 'checkbox':
+                return false;
+            default:
+                throw 'not implemented ' + funcType.type;
+        }
+    };
+
     $('#grid').w2grid({ 
         name    : 'grid', 
         header    : 'List of Names',
@@ -66,14 +116,16 @@ $(function () {
                 }
             },
             { field: 'check', caption: 'check', size: '40px', sortable: true, resizable: true, editable: { type: 'checkbox' } },
+            { field: 'funcValue', caption: 'func', size: '80px', sortable: true, resizable: true, editable: editFunc },
             // { field: 'enum', caption: 'enum', size: '380px', sortable: true, resizable: true, editable: { type: 'enum', items: people } },
             // { field: 'file', caption: 'file', size: '80px', sortable: true, resizable: true, editable: { type: 'file' } },
             // { field: 'radio', caption: 'radio', size: '80px', sortable: true, resizable: true, editable: { type: 'radio' } },
         ],
     });
-    var fname = ['Vitali', 'Katsia', 'John', 'Peter', 'Sue', 'Olivia', 'Thomas', 'Sergei', 'Snehal', 'Avinash', 'Divia'];
-    var lname = ['Peterson', 'Rene', 'Johnson', 'Cuban', 'Twist', 'Sidorov', 'Vasiliev', 'Yadav', 'Vaishnav'];
-    // add 10k records
+    // var fname = ['Vitali', 'Katsia', 'John', 'Peter', 'Sue', 'Olivia', 'Thomas', 'Sergei', 'Snehal', 'Avinash', 'Divia'];
+    // var lname = ['Peterson', 'Rene', 'Johnson', 'Cuban', 'Twist', 'Sidorov', 'Vasiliev', 'Yadav', 'Vaishnav'];
+    // add 15 records
+
     for (var i = 0; i < 15; i++) {
         w2ui['grid'].records.push({ 
             recid : (i + 10),
@@ -83,6 +135,8 @@ $(function () {
             money: 6,
             check: Math.random() > 0.9 ? true : false,
             select: 2,
+            funcType: getFuncType(i),
+            funcValue: getFuncValue(i)
             // editable: false
         });
     }


### PR DESCRIPTION
Added ability to set column.editable to a function that gets called for each record. This allows you to have a setting on the record that sets the edit type for that record.

Updated `test/grid2.html` to use this functionality.
