### PR TITLE
Fix "array to string" notice in PHP server example when using between operator

### DIFF
--- a/server/php/w2lib.php
+++ b/server/php/w2lib.php
@@ -22,9 +22,7 @@ class w2grid_class {
         if (isset($request['search']) && is_array($request['search'])) {
             foreach ($request['search'] as $s => $search) {
                 if ($str != "") $str .= " ".$request['searchLogic']." ";
-                $operator = "=";
-                $field       = $search['field'];
-                $value    = "'".$search['value']."'";
+                $field = $search['field'];
                 switch (strtolower($search['operator'])) {
 
                     case 'begins':
@@ -61,6 +59,10 @@ class w2grid_class {
                         $operator = "IN";
                         $value    = "[".$search['value']."]";
                         break;
+
+                    default:
+                        $operator = "=";
+                        $value    = "'".$search['value']."'";
                 }
                 $str .= $field." ".$operator." ".$value;
             }


### PR DESCRIPTION
When using "is" operator, search request is sent as: `&search[0][value]=`, but when using "between" operator, `&search[0][value][]=` is sent

This creates "Array to string conversion" notice on line 27 if notices are enabled (because it assumes search value is string) which mangles json formatted response.
