### PR TITLE
sudo is not needed for npm install

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -83,7 +83,7 @@ To use Grunt, you will still need to install NodeJS and NPM, then run npm instal
 they are described in package.json file.
 
 ```
-sudo npm install
+npm install
 ```
 
 ## File Structure


### PR DESCRIPTION
Installing dependencies to current dir through `npm install` prevents deleting local repo by current user.
