### PR TITLE
Fix 'recid' feature

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -248,7 +248,7 @@
             if (!$.isArray(record)) record = [record];
             var added = 0;
             for (var o in record) {
-                if (!this.recid && typeof record[o].recid == 'undefined') record[o].recid = record[o][this.recid];
+                if (this.recid && typeof record[o].recid == 'undefined') record[o].recid = record[o][this.recid];
                 if (record[o].recid == null || typeof record[o].recid == 'undefined') {
                     console.log('ERROR: Cannot add record without recid. (obj: '+ this.name +')');
                     continue;


### PR DESCRIPTION
The not symbol prevented from the this.recid to take any affect and required the data to already have the property 'recid'.
