### PR TITLE
allow override of edit field type on row level

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -2021,7 +2021,11 @@
             var index = obj.get(recid, true);
             var rec   = obj.records[index];
             var col   = obj.columns[column];
-            var edit  = col ? col.editable : null;
+            
+            var edit = rec ? rec.editable : null;
+            if (!edit)
+              edit = col ? col.editable : null;
+              
             if (!rec || !col || !edit || rec.editable === false) return;
             if (['enum', 'file'].indexOf(edit.type) != -1) {
                 console.log('ERROR: input types "enum" and "file" are not supported in inline editing.');


### PR DESCRIPTION
I wanted to make a property list, with a property and value column. Depending on the type of property a different type of edit field should appear (i.e. text field for propery A, combo for property B). With this commit you can use an editable property on row level, the same as on column level. Row level will override the column level setting, but column level editing must be set
