### PR TITLE
Datetime field

### DIFF
--- a/src/w2fields.js
+++ b/src/w2fields.js
@@ -262,6 +262,21 @@
                     break;
 
                 case 'datetime':
+                    defaults = {
+                        format      : w2utils.settings.date_format + '|hh24:mm',
+                        keyboard    : true,
+                        silent      : true,
+                        start       : '',       // string or jquery object or Date object
+                        end         : '',       // string or jquery object or Date object
+                        blocked     : [],       // [ '4/11/2011', '4/12/2011' ] or [ new Date(2011, 4, 11), new Date(2011, 4, 12) ]
+                        colored     : {},       // { '12/17/2014': 'blue:green', '12/18/2014': 'gray:white'  }; // key has be be formated with w2utils.settings.date_format
+                        placeholder : null,     // optional. will fall back to this.format if not specified. Only used if this.el has no placeholder attribute.
+                        format_mjs  : 'M/D/YYYY HH:mm', // date format for moment.js, should be equal to "this.format" translated to ISO 8601, see http://momentjs.com/docs/#/parsing/string-format
+                        btn_now     : true,     // show/hide the use-current-date-and-time button
+                    };
+                    this.options = $.extend(true, {}, defaults, options);
+                    options = this.options; // since object is re-created, need to re-assign
+                    if ($(this.el).attr('placeholder') == null) $(this.el).attr('placeholder', options.placeholder || options.format);
                     break;
 
                 case 'list':
@@ -841,12 +856,13 @@
                 setTimeout(function () { obj.refresh(); }, 5);
             }
             // date, time
-            if (['date', 'time'].indexOf(this.type) != -1) {
+            if (['date', 'time', 'datetime'].indexOf(this.type) != -1) {
                 // convert linux timestamps
                 var tmp = parseInt(obj.el.value);
                 if (w2utils.isInt(obj.el.value) && tmp > 3000) {
                     if (this.type == 'time') $(obj.el).val(w2utils.formatTime(new Date(tmp), options.format)).change();
                     if (this.type == 'date') $(obj.el).val(w2utils.formatDate(new Date(tmp), options.format)).change();
+                    if (this.type == 'datetime') $(obj.el).val(w2utils.formatDateTime(new Date(tmp), options.format)).change();
                 }
             }
         },
@@ -858,7 +874,7 @@
                 if (!$(this.el).is(':focus')) this.focus(event);
             }
             // other fields with drops
-            if (['date', 'time', 'color'].indexOf(this.type) != -1) {
+            if (['date', 'time', 'color', 'datetime'].indexOf(this.type) != -1) {
                 this.updateOverlay();
             }
         },
@@ -867,7 +883,7 @@
             var obj     = this;
             var options = this.options;
             // color, date, time
-            if (['color', 'date', 'time'].indexOf(obj.type) !== -1) {
+            if (['color', 'date', 'time', 'datetime'].indexOf(obj.type) !== -1) {
                 if ($(obj.el).attr('readonly') || $(obj.el).attr('disabled')) return;
                 if ($("#w2ui-overlay").length > 0) $('#w2ui-overlay')[0].hide();
                 setTimeout(function () { obj.updateOverlay(); }, 150);
@@ -897,7 +913,7 @@
             var options = obj.options;
             var val     = $(obj.el).val().trim();
             // hide overlay
-            if (['color', 'date', 'time', 'list', 'combo', 'enum'].indexOf(obj.type) != -1) {
+            if (['color', 'date', 'time', 'list', 'combo', 'enum', 'datetime'].indexOf(obj.type) != -1) {
                 if ($("#w2ui-overlay").length > 0) $('#w2ui-overlay')[0].hide();
             }
             if (['int', 'float', 'money', 'currency', 'percent'].indexOf(obj.type) != -1) {
@@ -910,7 +926,7 @@
                 }
             }
             // date or time
-            if (['date', 'time'].indexOf(obj.type) != -1) {
+            if (['date', 'time', 'datetime'].indexOf(obj.type) != -1) {
                 // check if in range
                 if (val !== '' && !obj.inRange(obj.el.value)) {
                     $(obj.el).val('').removeData('selected').change();
@@ -926,10 +942,17 @@
                             setTimeout(function () { $(obj.el).w2tag(''); }, 3000);
                         }
                     }
-                    if (obj.type == 'time' && val !== '' && !w2utils.isTime(obj.el.value)) {
+                    else if (obj.type == 'time' && val !== '' && !w2utils.isTime(obj.el.value)) {
                         $(obj.el).val('').removeData('selected').change();
                         if (options.silent === false) {
                             $(obj.el).w2tag('Not a valid time');
+                            setTimeout(function () { $(obj.el).w2tag(''); }, 3000);
+                        }
+                    }
+                    else if (obj.type == 'datetime' && val !== '' && !(options.use_moment_js ? w2utils.isDateTime(obj.el.value, options.format_mjs) : w2utils.isDateTime(obj.el.value, options.format))) {
+                        $(obj.el).val('').removeData('selected').change();
+                        if (options.silent === false) {
+                            $(obj.el).w2tag('Not a valid date');
                             setTimeout(function () { $(obj.el).w2tag(''); }, 3000);
                         }
                     }
@@ -960,7 +983,7 @@
                 }
             }
             // update date popup
-            if (['date', 'time'].indexOf(obj.type) != -1) {
+            if (['date', 'time', 'datetime'].indexOf(obj.type) != -1) {
                 setTimeout(function () { obj.updateOverlay(); }, 1);
             }
         },
@@ -1001,7 +1024,7 @@
                 if (!options.keyboard || $(obj.el).attr('readonly')) return;
                 var cancel  = false;
                 var daymil  = 24*60*60*1000;
-                var inc        = 1;
+                var inc     = 1;
                 if (event.ctrlKey || event.metaKey) inc = 10;
                 var dt = w2utils.isDate($(obj.el).val(), options.format, true);
                 if (!dt) { dt = new Date(); daymil = 0; }
@@ -1055,6 +1078,41 @@
                     setTimeout(function () {
                         // set cursor to the end
                         obj.el.setSelectionRange(obj.el.value.length, obj.el.value.length);
+                    }, 0);
+                }
+            }
+            // datetime
+            if (obj.type == 'datetime') {
+                if (!options.keyboard || $(obj.el).attr('readonly')) return;
+                var cancel  = false;
+                var daymil  = 24*60*60*1000;
+                var inc     = 1;
+                if (event.ctrlKey || event.metaKey) inc = 10;
+                var str = $(obj.el).val();
+                var dt = (w2utils.use_momentjs ? w2utils.isDateTime(str, this.options.format_mjs, true) : w2utils.isDateTime(str, this.options.format, true));
+                if (!dt) { dt = new Date(); daymil = 0; }
+                switch (key) {
+                    case 38: // up
+                        if (event.shiftKey) break; // no action if shift key is pressed
+                        var newDT = w2utils.formatDateTime(dt.getTime() + daymil, options.format);
+                        if (inc == 10) newDT = w2utils.formatDateTime(new Date(dt.getFullYear(), dt.getMonth()+1, dt.getDate()), options.format);
+                        $(obj.el).val(newDT).change();
+                        cancel = true;
+                        break;
+                    case 40: // down
+                        if (event.shiftKey) break; // no action if shift key is pressed
+                        var newDT = w2utils.formatDateTime(dt.getTime() - daymil, options.format);
+                        if (inc == 10) newDT = w2utils.formatDateTime(new Date(dt.getFullYear(), dt.getMonth()-1, dt.getDate()), options.format);
+                        $(obj.el).val(newDT).change();
+                        cancel = true;
+                        break;
+                }
+                if (cancel) {
+                    event.preventDefault();
+                    setTimeout(function () {
+                        // set cursor to the end
+                        obj.el.setSelectionRange(obj.el.value.length, obj.el.value.length);
+                        obj.updateOverlay();
                     }, 0);
                 }
             }
@@ -1567,6 +1625,133 @@
                             });
                     });
             }
+            // datetime
+            if (this.type == 'datetime') {
+                if ($(obj.el).attr('readonly')) return;
+                // hide overlay if we are in the time selection
+                if ($("#w2ui-overlay .w2ui-time").length > 0) $('#w2ui-overlay')[0].hide();
+                if ($('#w2ui-overlay').length == 0) {
+                    $(obj.el).w2overlay('<div class="w2ui-reset w2ui-calendar" onclick="event.stopPropagation();"></div>', {
+                        css: { "background-color": "#f5f5f5" }
+                    });
+                }
+                var month, year;
+                var dt = w2utils.isDate($(obj.el).val(), obj.options.format, true);
+                if (dt) { month = dt.getMonth() + 1; year = dt.getFullYear(); }
+                var selDate = null;
+                (function refreshCalendar(month, year) {
+                    $('#w2ui-overlay > div > div').html(obj.getMonthHTML(month, year, $(obj.el).val()));
+                    // add "now" button
+                    if(obj.options.btn_now) {
+                        $('#w2ui-overlay > div > div .w2ui-calendar-previous.previous').after('<div class="w2ui-calendar-previous now"></div>');
+                        // openclipart 194286
+                        var bg_image = "url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAQAAAC1+jfqAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dEAP+Hj8y/AAAACXBIWXMAAAsTAAALEwEAmpwYAAABDUlEQVQoz23QzyuDARgH8E+0hsSi6aWGklrz42CUiJVcFuXCmDZZKYZyQEocnDnt6B9xWXJ4/4CVUsp/4uLwbkX2fG/P93N4emg3I6aN62zbGXTkxqq8U5P/627nAs+G0ONYKlrHxZtgVc6AvCpIKkXrgt0mKCmriHkVA2c8CtXUhEKhL8+ehL692IzAu4Q9RYlmtlQkvEnJCRRooEuvwKCkMb1G9asL9KkajgBJd0rKHky7llNXUTVOC8QtSEvLGjAjUJfVEd3dsObWonv7DtyY8mBTXdB6TUPGnkkFK5ZtSNkx9xdkFWWUbMk7M6Fs6S+Yd2LWhV3bLqWdWP8NPl21yYe+Fsg6bJOlVv0DQzw+zwokgrkAAAAASUVORK5CYII=)";
+                        $('#w2ui-overlay div div.w2ui-calendar-previous.now').css({
+                            'width': '20px', 'text-align': 'center', 'vertical-align': 'middle', 'background-repeat': 'no-repeat', 'background-position': 'center', 'background-image': bg_image,
+                        });
+                    }
+                    $('#w2ui-overlay .w2ui-calendar-title')
+                        .on('mousedown', function () {
+                            if ($(this).next().hasClass('w2ui-calendar-jump')) {
+                                $(this).next().remove();
+                            } else {
+                                var selYear, selMonth;
+                                $(this).after('<div class="w2ui-calendar-jump" style=""></div>');
+                                $(this).next().hide().html(obj.getYearHTML()).fadeIn(200);
+                                setTimeout(function () {
+                                    $('#w2ui-overlay .w2ui-calendar-jump')
+                                        .find('.w2ui-jump-month, .w2ui-jump-year')
+                                        .on('click', function () {
+                                            if ($(this).hasClass('w2ui-jump-month')) {
+                                                $(this).parent().find('.w2ui-jump-month').removeClass('selected');
+                                                $(this).addClass('selected');
+                                                selMonth = $(this).attr('name');
+                                            }
+                                            if ($(this).hasClass('w2ui-jump-year')) {
+                                                $(this).parent().find('.w2ui-jump-year').removeClass('selected');
+                                                $(this).addClass('selected');
+                                                selYear = $(this).attr('name');
+                                            }
+                                            if (selYear != null && selMonth != null) {
+                                                $('#w2ui-overlay .w2ui-calendar-jump').fadeOut(100);
+                                                setTimeout(function () { refreshCalendar(parseInt(selMonth)+1, selYear); }, 100);
+                                            }
+                                        });
+                                    $('#w2ui-overlay .w2ui-calendar-jump >:last-child').prop('scrollTop', 2000);
+                                }, 1);
+                            }
+                        });
+                    $('#w2ui-overlay .w2ui-date')
+                        .on('mousedown', function () {
+                            var day = $(this).attr('date');
+                            $(obj.el).val(day).change();
+                            $(this).css({ 'background-color': '#B6D5FB', 'border-color': '#aaa' });
+                            selDate = new Date($(this).attr('data-date'));
+                        })
+                        .on('mouseup', function () {
+                            /*setTimeout(function () {
+                                if ($("#w2ui-overlay").length > 0) $('#w2ui-overlay').removeData('keepOpen')[0].hide();
+                            }, 10);*/
+                            // continue with time picker
+                            var selHour, selMin;
+                            if ($("#w2ui-overlay").length > 0) $('#w2ui-overlay')[0].hide();
+                            $(obj.el).w2overlay('<div class="w2ui-reset w2ui-calendar-time"></div>', { css: { "background-color": "#fff" } });
+                            var h24 = (obj.options.format == 'h24');
+                            $('#w2ui-overlay > div').html(obj.getHourHTML());
+                            $('#w2ui-overlay .w2ui-time')
+                                .on('mousedown', function (event) {
+                                    $(this).css({ 'background-color': '#B6D5FB', 'border-color': '#aaa' });
+                                    selHour = $(this).attr('hour');
+                                    selDate.setHours(selHour);
+                                    var txt = w2utils.formatDateTime(selDate, obj.options.format);
+                                    $(obj.el).val(txt).change();
+                                    //$(obj.el).val((hour > 12 && !h24 ? hour - 12 : hour) + ':00' + (!h24 ? (hour < 12 ? ' am' : ' pm') : '')).change();
+                                })
+                                .on('mouseup', function () {
+                                    var hour = $(this).attr('hour');
+                                    if ($("#w2ui-overlay").length > 0) $('#w2ui-overlay')[0].hide();
+                                    $(obj.el).w2overlay('<div class="w2ui-reset w2ui-calendar-time"></div>', { css: { "background-color": "#fff" } });
+                                    $('#w2ui-overlay > div').html(obj.getMinHTML(hour));
+                                    $('#w2ui-overlay .w2ui-time')
+                                        .on('mousedown', function () {
+                                            $(this).css({ 'background-color': '#B6D5FB', 'border-color': '#aaa' });
+                                            selMin = $(this).attr('min');
+                                            selDate.setHours(selHour, selMin);
+                                            var txt = w2utils.formatDateTime(selDate, obj.options.format);
+                                            $(obj.el).val(txt).change();
+                                            //$(obj.el).val((hour > 12 && !h24 ? hour - 12 : hour) + ':' + (min < 10 ? 0 : '') + min + (!h24 ? (hour < 12 ? ' am' : ' pm') : '')).change();
+                                        })
+                                        .on('mouseup', function () {
+                                            setTimeout(function () { if ($("#w2ui-overlay").length > 0) $('#w2ui-overlay').removeData('keepOpen')[0].hide(); }, 10);
+                                        });
+                                });
+                        });
+                    $('#w2ui-overlay .previous').on('mousedown', function () {
+                        var tmp = obj.options.current.split('/');
+                        tmp[0]  = parseInt(tmp[0]) - 1;
+                        refreshCalendar(tmp[0], tmp[1]);
+                    });
+                    $('#w2ui-overlay .next').on('mousedown', function () {
+                        var tmp = obj.options.current.split('/');
+                        tmp[0]  = parseInt(tmp[0]) + 1;
+                        refreshCalendar(tmp[0], tmp[1]);
+                    });
+                    // "now" button
+                    $('#w2ui-overlay .now')
+                        .on('mousedown', function () {
+                            // this currently ignores blocked days or start / end dates!
+                            var day = w2utils.formatDateTime(new Date(), obj.options.format);
+                            $(obj.el).val(day).change();
+                            //$(this).css({ 'background-color': '#B6D5FB', 'border-color': '#aaa' });
+                            return false;
+                        })
+                        .on('mouseup', function () {
+                            setTimeout(function () {
+                                if ($("#w2ui-overlay").length > 0) $('#w2ui-overlay').removeData('keepOpen')[0].hide();
+                            }, 10);
+                        });
+                }) (month, year);
+            }
             // list
             if (['list', 'combo', 'enum'].indexOf(this.type) != -1) {
                 var el    = this.el;
@@ -1650,7 +1835,7 @@
                     if (this.options.blocked && $.inArray(str, this.options.blocked) != -1) inRange = false;
                 }
             }
-            if (this.type == 'time') {
+            else if (this.type == 'time') {
                 if (this.options.start || this.options.end) {
                     var tm  = this.toMin(str);
                     var tm1 = this.toMin(this.options.start);
@@ -1660,6 +1845,54 @@
                     if (tm >= tm1 && tm <= tm2) inRange = true;
                 } else {
                     inRange = true;
+                }
+            }
+            else if (this.type == 'datetime') {
+                var dt = (w2utils.use_momentjs ? w2utils.isDateTime(str, this.options.format_mjs, true) : w2utils.isDateTime(str, this.options.format, true));
+                if (dt) {
+                    // enable range
+                    if (this.options.start || this.options.end) {
+                        var start, end;
+                        if(typeof this.options.start == 'object' && this.options.start instanceof Date) {
+                            start = this.options.start;
+                        } else {
+                            var st = (typeof this.options.start == 'string' ? this.options.start : $(this.options.start).val());
+                            start  = (w2utils.use_momentjs ? w2utils.isDateTime(st, this.options.format_mjs, true) : w2utils.isDateTime(st, this.options.format, true));
+                        }
+                        if(typeof this.options.end == 'object' && this.options.end instanceof Date) {
+                            end = this.options.end;
+                        } else {
+                            var en = (typeof this.options.end == 'string' ? this.options.end : $(this.options.end).val());
+                            end    = (w2utils.use_momentjs ? w2utils.isDateTime(en, this.options.format_mjs, true) : w2utils.isDateTime(en, this.options.format, true));
+                        }
+                        var current = dt; // new Date(dt);
+                        if (!start) start = current;
+                        if (!end) end = current;
+                        if (current >= start && current <= end) inRange = true;
+                        /*console.log(str);
+                        console.log(this.options.format_mjs);
+                        console.log(start);
+                        console.log(end);
+                        console.log(current);
+                        console.log("inRange: " + inRange);//*/
+                    } else {
+                        inRange = true;
+                    }
+                    // block predefined dates
+                    if (inRange && this.options.blocked) {
+                        for (var i=0; i<this.options.blocked.length; i++) {
+                            var blocked = this.options.blocked[i];
+                            if(typeof blocked == 'string') {
+                                // convert string to Date object
+                                blocked = (w2utils.use_momentjs ? w2utils.isDateTime(blocked, this.options.format_mjs, true) : w2utils.isDateTime(blocked, this.options.format, true));
+                            }
+                            // check for Date object with the same day
+                            if(typeof blocked == 'object' && blocked instanceof Date && (blocked.getFullYear() == dt.getFullYear() && blocked.getMonth() == dt.getMonth() && blocked.getDate() == dt.getDate())) {
+                                inRange = false;
+                                break;
+                            }
+                        }
+                    }
                 }
             }
             return inRange;
@@ -2183,6 +2416,10 @@
 
             var day = 1;
             if (w2utils.settings.weekStarts != 'M') weekDay++;
+            if(this.type === 'datetime') {
+                var dt_sel = (w2utils.use_momentjs ? w2utils.isDateTime(selected, this.options.format_mjs, true) : w2utils.isDateTime(selected, this.options.format, true));
+                selected = w2utils.formatDate(dt_sel, w2utils.settings.date_format);
+            }
             for (var ci = 1; ci < 43; ci++) {
                 if (weekDay === 0 && ci == 1) {
                     for (var ti = 0; ti < 6; ti++) html += '<td class="w2ui-day-empty">&nbsp;</td>';
@@ -2204,14 +2441,21 @@
                 var dspDay  = day;
                 var col     = '';
                 var bgcol   = '';
-                var tmp_dt  = w2utils.formatDate(dt, this.options.format);
-                if (this.options.colored && this.options.colored[tmp_dt] !== undefined) { // if there is predefined colors for dates
-                    var tmp = this.options.colored[tmp_dt].split(':');
+                var tmp_dt, tmp_dt_fmt;
+                if(this.type === 'datetime') {
+                    tmp_dt      = w2utils.formatDateTime(dt, this.options.format);
+                    tmp_dt_fmt  = w2utils.formatDate(dt, w2utils.settings.date_format);
+                } else {
+                    tmp_dt      = w2utils.formatDate(dt, this.options.format);
+                    tmp_dt_fmt  = tmp_dt;
+                }
+                if (this.options.colored && this.options.colored[tmp_dt_fmt] !== undefined) { // if there is predefined colors for dates
+                    var tmp = this.options.colored[tmp_dt_fmt].split(':');
                     bgcol   = 'background-color: ' + tmp[0] + ';';
                     col     = 'color: ' + tmp[1] + ';';
                 }
-                html += '<td class="'+ (this.inRange(tmp_dt) ? 'w2ui-date ' + (tmp_dt == selected ? 'w2ui-date-selected' : '') : 'w2ui-blocked') + className + '" '+
-                        '   style="'+ col + bgcol + '" date="'+ tmp_dt +'">'+
+                html += '<td class="'+ (this.inRange(tmp_dt) ? 'w2ui-date ' + (tmp_dt_fmt == selected ? 'w2ui-date-selected' : '') : 'w2ui-blocked') + className + '" '+
+                        '   style="'+ col + bgcol + '" date="'+ tmp_dt +'" data-date="'+ DT +'">'+
                             dspDay +
                         '</td>';
                 if (ci % 7 === 0 || (weekDay === 0 && ci == 1)) html += '</tr><tr>';
@@ -2236,14 +2480,14 @@
 
         getHourHTML: function () {
             var tmp = [];
-            var h24 = (this.options.format == 'h24');
+            var h24 = (this.options.format.indexOf('h24') > -1);
             for (var a = 0; a < 24; a++) {
                 var time = (a >= 12 && !h24 ? a - 12 : a) + ':00' + (!h24 ? (a < 12 ? ' am' : ' pm') : '');
                 if (a == 12 && !h24) time = '12:00 pm';
                 if (!tmp[Math.floor(a/8)]) tmp[Math.floor(a/8)] = '';
                 var tm1 = this.fromMin(this.toMin(time));
                 var tm2 = this.fromMin(this.toMin(time) + 59);
-                tmp[Math.floor(a/8)] += '<div class="'+ (this.inRange(tm1) || this.inRange(tm2) ? 'w2ui-time ' : 'w2ui-blocked') + '" hour="'+ a +'">'+ time +'</div>';
+                tmp[Math.floor(a/8)] += '<div class="'+ ((this.type === 'datetime') || this.inRange(tm1) || this.inRange(tm2) ? 'w2ui-time ' : 'w2ui-blocked') + '" hour="'+ a +'">'+ time +'</div>';
             }
             var html =
                 '<div class="w2ui-calendar-time"><table><tr>'+
@@ -2256,13 +2500,13 @@
 
         getMinHTML: function (hour) {
             if (typeof hour == 'undefined') hour = 0;
-            var h24 = (this.options.format == 'h24');
+            var h24 = (this.options.format.indexOf('h24') > -1);
             var tmp = [];
             for (var a = 0; a < 60; a += 5) {
                 var time = (hour > 12 && !h24 ? hour - 12 : hour) + ':' + (a < 10 ? 0 : '') + a + ' ' + (!h24 ? (hour < 12 ? 'am' : 'pm') : '');
                 var ind = a < 20 ? 0 : (a < 40 ? 1 : 2);
                 if (!tmp[ind]) tmp[ind] = '';
-                tmp[ind] += '<div class="'+ (this.inRange(time) ? 'w2ui-time ' : 'w2ui-blocked') + '" min="'+ a +'">'+ time +'</div>';
+                tmp[ind] += '<div class="'+ ((this.type === 'datetime') || this.inRange(time) ? 'w2ui-time ' : 'w2ui-blocked') + '" min="'+ a +'">'+ time +'</div>';
             }
             var html =
                 '<div class="w2ui-calendar-time"><table><tr>'+

--- a/src/w2utils.js
+++ b/src/w2utils.js
@@ -73,6 +73,7 @@ var w2utils = (function () {
         isEmail         : isEmail,
         isDate          : isDate,
         isTime          : isTime,
+        isDateTime      : isDateTime,
         age             : age,
         date            : date,
         formatSize      : formatSize,
@@ -103,7 +104,8 @@ var w2utils = (function () {
                  ? true : false),
         isIE : ((navigator.userAgent.toLowerCase().indexOf('msie') != -1 ||
                  navigator.userAgent.toLowerCase().indexOf('trident') != -1 )
-                 ? true : false)
+                 ? true : false),
+        use_momentjs : ((typeof moment === 'function') && (typeof moment.version === 'string'))
     };
     return obj;
 
@@ -235,6 +237,22 @@ var w2utils = (function () {
             };
         }
         return true;
+    }
+
+    function isDateTime (val, format, retDate) {
+        if(w2utils.use_momentjs) {
+            var dt = moment(val, format);
+            var valid = dt.isValid();
+            if (valid && (retDate === true)){
+                return dt.clone().toDate();
+            }
+            return valid;
+        }
+        // TODO: perform time check, too
+        format = format.split('|')[0];
+        val    = val.split(' ')[0];
+        //console.log("isDateTime() - " + val + " / " + format);
+        return isDate(val, format, retDate);
     }
 
     function age (dateStr) {


### PR DESCRIPTION
Implementation of a datetime field with an optional "now" button to immediately set current date and time.

The "now" button is visible by default.

Moment.js is supported but is not required. When using moment.js the formatting for moment (field.format_mjs) has to be set.

All features of date field should be supported. (Limitation: colored days need to be formatted with w2utils.settings.date_format instead of the format used on field.format)

Enhancements: start, end and blocked days can also be Date object in addition to the the existing values (formated string, jquery object).

To make a field from the date and time examples (http://w2ui.com/web/docs/form/fields-date) behave like a datetime field, the following code snippet could be used:

```
type_date = 'datetime';
// for US format:
eu_format       = 'm/d/yyyy|hh:mm';
eu_format_m     = 'M/D/YYYY HH:mm';
eu_placeholder  = eu_format_m.toLowerCase();
// for EU format:
eu_format       = 'dd.mm.yyyy|hh24:mm:ss';
eu_format_m     = 'DD.MM.YYYY HH:mm:ss';
eu_placeholder  = eu_format_m.toLowerCase();

$('input[type=eu-date]' ).w2field(type_date, { format: eu_format, format_mjs: eu_format_m, placeholder: eu_placeholder });
```

**Notes:**

The function isDateTime() still needs work, to validate the time part if moment.js is not used.

There is currently no option to block time values.
