### PR TITLE
Remove dual call to resize() on refresh() method

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -3477,7 +3477,7 @@
             this.trigger($.extend(eventData, { phase: 'after' }));
             obj.resize();
             obj.addRange('selection');
-            setTimeout(function () { obj.resize(); obj.scroll(); }, 1); // allow to render first
+            setTimeout(function () { obj.scroll(); }, 1); // allow to render first
 
             if ( obj.reorderColumns && !obj.last.columnDrag ) {
                 obj.last.columnDrag = obj.initColumnDrag();


### PR DESCRIPTION
On refresh: method, obj.resize is called two times (lines 3478 and 3480)
Removing, improve as well a little the refresh performance
