### PR TITLE
Allow start/end year of date-picker to be set through w2ui.settings

### DIFF
--- a/src/w2fields.js
+++ b/src/w2fields.js
@@ -2467,12 +2467,14 @@
 
         getYearHTML: function () {
             var months = w2utils.settings.shortmonths;
+            var start_year = w2utils.settings.dateStartYear;
+            var end_year = w2utils.settings.dateEndYear;
             var mhtml  = '';
             var yhtml  = '';
             for (var m = 0; m < months.length; m++) {
                 mhtml += '<div class="w2ui-jump-month" name="'+ m +'">'+ months[m] + '</div>';
             }
-            for (var y = 1950; y <= 2020; y++) {
+            for (var y = start_year; y <= end_year; y++) {
                 yhtml += '<div class="w2ui-jump-year" name="'+ y +'">'+ y + '</div>';
             }
             return '<div>'+ mhtml +'</div><div>'+ yhtml +'</div>';

--- a/src/w2utils.js
+++ b/src/w2utils.js
@@ -65,7 +65,9 @@ var w2utils = (function () {
             "fulldays"          : ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"],
             "weekStarts"        : "M",      // can be "M" for Monday or "S" for Sunday
             "dataType"          : 'HTTP',   // can be HTTP, RESTFULL, JSON (case sensative)
-            "phrases"           : {}        // empty object for english phrases
+            "phrases"           : {},       // empty object for english phrases
+            "dateStartYear"     : 1950,     // start year for date-picker
+            "dateEndYear"       : 2020      // end year for date picker
         },
         isInt           : isInt,
         isFloat         : isFloat,


### PR DESCRIPTION
Date-picker star and end years are hard-coded (1950 and 2020, respectively). This patch allows one to set those parameters as

  w2utils.settings['dateStartYear'] = 1800;
  w2utils.settings['dateEndYear'] = 2014;

thus, not limiting the possible range of date-picker's dates to 1950-2020
