### PR TITLE
add event when rendering subnodes

### DIFF
--- a/src/w2sidebar.js
+++ b/src/w2sidebar.js
@@ -8,7 +8,7 @@
 * == NICE TO HAVE ==
 *   - add find() method to find nodes by a specific criteria (I want all nodes for exampe)
 *   - dbl click should be like it is in grid (with timer not HTML dbl click event)
-*   - reorder with grag and drop
+*   - reorder with drag and drop
 *   - node.style is missleading - should be there to apply color for example
 *   - add multiselect
 *   - add renderer for the node

--- a/src/w2sidebar.js
+++ b/src/w2sidebar.js
@@ -753,10 +753,16 @@
             // refresh sub nodes
             $(this.box).find(nm).html('');
             for (var i = 0; i < node.nodes.length; i++) {
-                nd = node.nodes[i];
-                nodeHTML = getNodeHTML(nd);
-                $(this.box).find(nm).append(nodeHTML);
-                if (nd.nodes.length !== 0) { this.refresh(nd.id); }
+               nd = node.nodes[i];
+               var eventData_SubNode = this.trigger({ phase: 'before', type: 'renderNode', node: nd });
+               if (eventData.isCancelled !== true) {
+                  nodeHTML = getNodeHTML(nd);
+                  $(this.box).find(nm).append(nodeHTML);
+               }
+               eventData_SubNode=this.trigger($.extend(eventData_SubNode, { phase: 'after', target: nd.id }));
+               if (eventData.isCancelled !== true) {
+                  if (nd.nodes.length !== 0) { this.refresh(nd.id); }
+               }
             }
             // event after
             this.trigger($.extend(eventData, { phase: 'after' }));


### PR DESCRIPTION
I've been a bit confused while reading the docs about onRefresh event. Which actually does not fire when subnodes will be rendered.

Instead of firing onRefresh i decided to use a new event onRenderNode.

Maybe onRefresh, onRender and onRenderNode should be merged into one event which has an additional parameter which holds the type?