### PR TITLE
more explicit definition to fix conflict with foundation.css

### DIFF
--- a/dist/w2ui-dark.css
+++ b/dist/w2ui-dark.css
@@ -67,14 +67,17 @@
   margin: 0px;
   padding: 0px;
 }
+.w2ui-reset table {
+  background-color: transparent;
+  border-collapse: separate;
+  border-spacing: 0;  
+  border: none;
+  max-width: none;
+}
 .w2ui-reset table tr th,
 .w2ui-reset table tr td {
   font-family: Verdana, Arial, sans-serif;
   font-size: 11px;
-  max-width: none;
-  background-color: transparent;
-  border-collapse: separate;
-  border-spacing: 0;
 }
 .w2ui-reset input,
 .w2ui-reset textarea {

--- a/dist/w2ui-dark.css
+++ b/dist/w2ui-dark.css
@@ -67,6 +67,7 @@
   margin: 0px;
   padding: 0px;
 }
+.w2ui-reset table tr th,
 .w2ui-reset table tr td {
   font-family: Verdana, Arial, sans-serif;
   font-size: 11px;

--- a/dist/w2ui-dark.css
+++ b/dist/w2ui-dark.css
@@ -67,7 +67,7 @@
   margin: 0px;
   padding: 0px;
 }
-.w2ui-reset table {
+.w2ui-reset table tr td {
   font-family: Verdana, Arial, sans-serif;
   font-size: 11px;
   max-width: none;

--- a/dist/w2ui-fields.css
+++ b/dist/w2ui-fields.css
@@ -24,7 +24,7 @@
   margin: 0px;
   padding: 0px;
 }
-.w2ui-reset table {
+.w2ui-reset table tr td {
   font-family: Verdana, Arial, sans-serif;
   font-size: 11px;
   max-width: none;

--- a/dist/w2ui-fields.css
+++ b/dist/w2ui-fields.css
@@ -24,6 +24,7 @@
   margin: 0px;
   padding: 0px;
 }
+.w2ui-reset table tr th,
 .w2ui-reset table tr td {
   font-family: Verdana, Arial, sans-serif;
   font-size: 11px;

--- a/dist/w2ui-fields.css
+++ b/dist/w2ui-fields.css
@@ -24,14 +24,17 @@
   margin: 0px;
   padding: 0px;
 }
+.w2ui-reset table {
+  background-color: transparent;
+  border-collapse: separate;
+  border-spacing: 0;
+  border: none;
+  max-width: none;
+}
 .w2ui-reset table tr th,
 .w2ui-reset table tr td {
   font-family: Verdana, Arial, sans-serif;
   font-size: 11px;
-  max-width: none;
-  background-color: transparent;
-  border-collapse: separate;
-  border-spacing: 0;
 }
 .w2ui-reset input,
 .w2ui-reset textarea {


### PR DESCRIPTION
Would it be ok to add a more explicit reset definition for table stylings? 
foundation.css rules aren't being properly reset.
foundation.css defines tables as:
```
table tr th,
table tr td {
  padding: 0.5625rem 0.625rem;
  font-size: 0.875rem;
  color: #222222;
  text-align: left;
}
```