### PR TITLE
Search field placeholder change behavior fix

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -1725,7 +1725,7 @@
             }
             // update field
             if (this.last.search != '') {
-				this.last.caption = search.caption;
+                this.last.caption = search.caption;
                 this.search(search.field, this.last.search);
             } else {
                 this.last.field   = search.field;

--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -1725,6 +1725,7 @@
             }
             // update field
             if (this.last.search != '') {
+				this.last.caption = search.caption;
                 this.search(search.field, this.last.search);
             } else {
                 this.last.field   = search.field;


### PR DESCRIPTION
Search input placeholder has incorrect value after changing it on "all fields", if only search value is not empty.