### PR TITLE
Mind the checked state of check, drop, menu when refreshing the toolbar

### DIFF
--- a/src/w2toolbar.js
+++ b/src/w2toolbar.js
@@ -362,6 +362,14 @@
                 el.html(html);
                 if (it.hidden) { el.css('display', 'none'); } else { el.css('display', ''); }
                 if (it.disabled) { el.addClass('disabled'); } else { el.removeClass('disabled'); }
+                if (it.type == 'check' || it.type == 'drop' || it.type == 'menu') {
+                    var btn = '#tb_'+ this.name +'_item_'+ w2utils.escapeId(it.id) +' table.w2ui-button';
+                    if (it.checked) {
+                        $(btn).addClass('checked');
+                    } else {
+                        $(btn).removeClass('checked');
+                    }
+                }                
             }
             // event after
             this.trigger($.extend(eventData, { phase: 'after' }));


### PR DESCRIPTION
This request applies/removes the 'checked' class for check/drop/menu items when the toolbar is refreshed.