### PR TITLE
Added RESTFULJSON datatype for RESTFUL JSON communication

### DIFF
--- a/src/w2form.js
+++ b/src/w2form.js
@@ -442,6 +442,11 @@
                 ajaxOptions.type = 'GET';
                 ajaxOptions.data = String($.param(ajaxOptions.data, false)).replace(/%5B/g, '[').replace(/%5D/g, ']');
             }
+            if (w2utils.settings.dataType == 'RESTFULLJSON') {
+                ajaxOptions.type = 'GET';
+                ajaxOptions.data        = JSON.stringify(ajaxOptions.data);
+                ajaxOptions.contentType = 'application/json';
+            }
             if (w2utils.settings.dataType == 'JSON') {
                 ajaxOptions.type        = 'POST';
                 ajaxOptions.data        = JSON.stringify(ajaxOptions.data);
@@ -598,6 +603,11 @@
                 if (w2utils.settings.dataType == 'RESTFULL') {
                     if (obj.recid != 0 && obj.recid != null) ajaxOptions.type = 'PUT';
                     ajaxOptions.data = String($.param(ajaxOptions.data, false)).replace(/%5B/g, '[').replace(/%5D/g, ']');
+                }
+                if (w2utils.settings.dataType == 'RESTFULLJSON') {
+                    if (obj.recid != 0 && obj.recid != null) ajaxOptions.type = 'PUT';
+                    ajaxOptions.data        = JSON.stringify(ajaxOptions.data);
+                    ajaxOptions.contentType = 'application/json';
                 }
                 if (w2utils.settings.dataType == 'JSON') {
                     ajaxOptions.type        = 'POST';

--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -1895,6 +1895,13 @@
                 if (params.cmd == 'delete-records') ajaxOptions.type = 'DELETE';
                 ajaxOptions.data = (typeof ajaxOptions.data == 'object' ? String($.param(ajaxOptions.data, false)).replace(/%5B/g, '[').replace(/%5D/g, ']') : ajaxOptions.data);
             }
+            if (w2utils.settings.dataType == 'RESTFULLJSON') {
+                ajaxOptions.type = 'GET';
+                if (params.cmd == 'save-records')   ajaxOptions.type = 'PUT';  // so far it is always update
+                if (params.cmd == 'delete-records') ajaxOptions.type = 'DELETE';
+                ajaxOptions.data        = JSON.stringify(ajaxOptions.data);
+                ajaxOptions.contentType = 'application/json';
+            }
             if (w2utils.settings.dataType == 'JSON') {
                 ajaxOptions.type        = 'POST';
                 ajaxOptions.data        = JSON.stringify(ajaxOptions.data);

--- a/src/w2utils.js
+++ b/src/w2utils.js
@@ -68,7 +68,7 @@ var w2utils = (function () {
             "shortdays"         : ["M", "T", "W", "T", "F", "S", "S"],
             "fulldays"          : ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"],
             "weekStarts"        : "M",      // can be "M" for Monday or "S" for Sunday
-            "dataType"          : 'HTTP',   // can be HTTP, RESTFULL, JSON (case sensative)
+            "dataType"          : 'HTTP',   // can be HTTP, RESTFULL, RESTFULLJSON, JSON (case sensative)
             "phrases"           : {},       // empty object for english phrases
             "dateStartYear"     : 1950,     // start year for date-picker
             "dateEndYear"       : 2020      // end year for date picker


### PR DESCRIPTION
In a lot of languages it's very hard to handle those php-style args w2ui is passing. JSON just works. Also, according to REST, the data format is up to the service, and not to the client.  I think this is kinda useful, JSON is way easier to handle than those nested args, it just works out of the box.
