### PR TITLE
Removed file attribute from newItem object

### DIFF
--- a/src/w2fields.js
+++ b/src/w2fields.js
@@ -2295,8 +2295,7 @@
                 type     : file.type,
                 modified : file.lastModifiedDate,
                 size     : file.size,
-                content  : null,
-                file     : file
+                content  : null
             };
             var size = 0;
             var cnt  = 0;


### PR DESCRIPTION
This update resolves an exception that occurs when parametrizing the value for a 'file' field. 
If the File object is contained within the record when it is parameterized by $.param, a 'Uncaught TypeError: Illegal invocation' is thrown. 
By removing this attribute, the form is successfully parameterized and sent to the server.