### PR TITLE
Perform selective refresh on expandParents.

### DIFF
--- a/src/w2sidebar.js
+++ b/src/w2sidebar.js
@@ -440,10 +440,12 @@
             var node = this.get(id);
             if (node === null) return false;
             if (node.parent) {
-                node.parent.expanded = true;
+                if (!node.parent.expanded) {
+                    node.parent.expanded = true;
+                    this.refresh(node.parent.id);
+                }
                 this.expandParents(node.parent.id);
             }
-            this.refresh(id);
             return true;
         },
 


### PR DESCRIPTION
Only refresh parents which have their expanded property changed to true. This prevents unnecessary refreshes.