### PR TITLE
Animation on fields hide/show in form

### DIFF
--- a/src/w2form.js
+++ b/src/w2form.js
@@ -206,26 +206,18 @@
         show: function () {
             var affected = 0;
             for (var a = 0; a < arguments.length; a++) {
-                var fld = this.get(arguments[a]);
-                if (fld && fld.hidden) { 
-                    fld.hidden = false;
-                    affected++;
-                }
+                $('div[name='+this.name+'] div[class="w2ui-page page-'+this.get(arguments[a]).page+'"] > div > div:eq('+this.get(arguments[a], true)+')').show(500);
+                affected++;
             }
-            if (affected > 0) this.refresh();
             return affected;
         },
 
         hide: function () {
             var affected = 0;
             for (var a = 0; a < arguments.length; a++) {
-                var fld = this.get(arguments[a]);
-                if (fld && !fld.hidden) { 
-                    fld.hidden = true;
-                    affected++;
-                }
+                $('div[name='+this.name+'] div[class="w2ui-page page-'+this.get(arguments[a]).page+'"] > div > div:eq('+this.get(arguments[a], true)+')').hide(500);
+                affected++;
             }
-            if (affected > 0) this.refresh();
             return affected;
         },
 

--- a/src/w2form.js
+++ b/src/w2form.js
@@ -175,7 +175,7 @@
         msgRefresh    : w2utils.lang('Refreshing...'),
         msgSaving     : w2utils.lang('Saving...'),
 
-        get: function (field, returnIndex) {
+        get: function (field, returnIndex, pageIndex) {
             if (arguments.length === 0) {
                 var all = [];
                 for (var f1 = 0; f1 < this.fields.length; f1++) {
@@ -183,9 +183,21 @@
                 }
                 return all;
             } else {
+                var currentPage = 0;
+                var indexOnPage = 0;
                 for (var f2 = 0; f2 < this.fields.length; f2++) {
+                    if (this.fields[f2].page != currentPage) {
+                        indexOnPage = 0;
+                        currentPage = this.fields[f2].page;
+                    } else {
+                        indexOnPage++;
+                    }
                     if (this.fields[f2].name == field) {
-                        if (returnIndex === true) return f2; else return this.fields[f2];
+                        if (returnIndex === true) {
+                            if (pageIndex === true) return indexOnPage; else return f2;
+                        }  else {
+                            return this.fields[f2];
+                        }
                     }
                 }
                 return null;
@@ -206,7 +218,7 @@
         show: function () {
             var affected = 0;
             for (var a = 0; a < arguments.length; a++) {
-                $('div[name='+this.name+'] div[class="w2ui-page page-'+this.get(arguments[a]).page+'"] > div > div:eq('+this.get(arguments[a], true)+')').show(500);
+                $('div[name='+this.name+'] div[class="w2ui-page page-'+this.get(arguments[a]).page+'"] > div > div:eq('+this.get(arguments[a], true, true)+')').show(500);
                 affected++;
             }
             return affected;
@@ -215,7 +227,7 @@
         hide: function () {
             var affected = 0;
             for (var a = 0; a < arguments.length; a++) {
-                $('div[name='+this.name+'] div[class="w2ui-page page-'+this.get(arguments[a]).page+'"] > div > div:eq('+this.get(arguments[a], true)+')').hide(500);
+                $('div[name='+this.name+'] div[class="w2ui-page page-'+this.get(arguments[a]).page+'"] > div > div:eq('+this.get(arguments[a], true, true)+')').hide(500);
                 affected++;
             }
             return affected;


### PR DESCRIPTION
In some applications some form elements may appear or dissapear dynamically depending on values entered in input fields.  If form elements are hiding or showing suddenly, for user it may be difficult to understand what happened. So it would be really nice to have some animation when fields are hiding/showing. It explains relation logic between various form elements.
In my proposed code I implemented hiding/showing of form elements without refreshing the form, so the actions can be animated.

To make show() and hide() work on multitab forms I have to update get() function too. Hope this does not breaks the library somewhere.