### PR TITLE
Work In Progress: Make OR/AND local search more flexible.

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -777,7 +777,10 @@
                 this.total = 0;
                 for (var i = 0; i < this.records.length; i++) {
                     var rec = this.records[i];
-                    var fl  = 0;
+                    var orNb = 0;
+                    var orTot = 0;
+                    var andNb = 0;
+                    var andTot = 0;
                     for (var j = 0; j < this.searchData.length; j++) {
                         var sdata  = this.searchData[j];
                         var search = this.getSearch(sdata.field);
@@ -795,6 +798,7 @@
                                 var val3 = sdata.value[1];
                             }
                         }
+                        var fl = 0;
                         switch (sdata.operator) {
                             case 'is':
                                 if (obj.parseField(rec, search.field) == sdata.value) fl++; // do not hide record
@@ -898,10 +902,18 @@
                                 if (lastIndex !== -1 && lastIndex == val1.length - val2.length) fl++; // do not hide record
                                 break;
                         }
+                        if (sdata.required || this.last.logic == 'AND') {       /* required field */
+                            andTot++;
+                            andNb += fl;
+                            if (!fl)
+                                break;                                           /* short circuit evaluation */
+                        } else {
+                            orTot++;
+                            orNb += fl;
+                        }
                     }
-                    if ((this.last.logic == 'OR' && fl != 0) || (this.last.logic == 'AND' && fl == this.searchData.length)) {
+                    if (andNb == andTot && (!orTot || orNb > 0))
                         this.last.searchIds.push(parseInt(i));
-                    }
                 }
                 this.total = this.last.searchIds.length;
             }


### PR DESCRIPTION
This pull request is not for merging at that point, but to get early feedback before doing more work.

In the grid, the search data currently consist of two distinct pieces of information:
  - The array in searchData (http://w2ui.com/web/docs/w2grid.searchData)
  - 'AND' or 'OR' in last.logic.

I see two problems with that:
  - This makes the API and code complicated to read, understand and use.
  - This is not very flexible. for example, when working with a time-serie grid,
    I wanted to search for (T > T1 AND T < T2 AND (OR-based full text search on all columns)).

I would like to improve and simplify the code the following way:
  - Completely remove the global 'AND' and 'OR' logic flag (last.logic).
  - Handle the following two new flags for each structure in the searchData array:
    - 'required': if true, this field indicated that the condition MUST be satisfied (behave like AND)
    - 'not': if true, this field invert the condition (so we can add test like string do not begin with "Input_") .

The diff included in this pull request shows the minimal code I'm using right now to implements the 'required' field, in a backward compatible way.
The test loop go through every condition in searchData, and:
 - if the entry has the 'required' flag set, it must be satisfied.
 - if there are entries without the 'required' flag set, at least _one_ of them must be satisfied.
  
What do you think?
Does it make sense for me to complete the code up to the removal of 'last.logic' and associated code?
