### PR TITLE
Fix #838

### DIFF
--- a/src/w2fields.js
+++ b/src/w2fields.js
@@ -1019,7 +1019,7 @@
             }
             // update date popup
             if (['date', 'time', 'datetime'].indexOf(obj.type) != -1) {
-                setTimeout(function () { obj.updateOverlay(); }, 1);
+                if (event.keyCode !== 9) setTimeout(function () { obj.updateOverlay(); }, 1);
             }
         },
 


### PR DESCRIPTION
Here is a demo of the issue using Firefox / Chrome (there was no problem using IE).

 I am using <kbd>TAB</kbd> and <kbd>SHIFT</kbd>+<kbd>TAB</kbd> in order to navigate through the fields. As you can see, the box appears at the wrong field.

![Issue demo](https://cloud.githubusercontent.com/assets/4193924/10319942/0bde9354-6c71-11e5-8a76-6f7de54f1d6d.gif)

[ChandrakantaPal](ChandrakantaPal), who reported the issue, also provided [a fix to it](https://github.com/ChandrakantaPal/w2ui/commit/bae5203430ba6e771cbae0094bdddddd554ef5d2). So I think it should be merged.
