### PR TITLE
w2grid.js: protect against null pointer

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -4033,7 +4033,7 @@
                     for (var s = 0; s < obj.searchData.length; s++) {
                         var sdata = obj.searchData[s];
                         var fld = obj.getSearch(sdata.field);
-                        if (fld.hidden) continue;
+                        if (!fld || fld.hidden) continue;
                         if (str.indexOf(sdata.value) == -1) str.push(sdata.value);
                     }
                     if (str.length > 0) $(obj.box).find('.w2ui-grid-data > div').w2marker(str);
@@ -6240,7 +6240,7 @@
                     for (var s = 0; s < obj.searchData.length; s++) {
                         var sdata = obj.searchData[s];
                         var fld = obj.getSearch(sdata.field);
-                        if (fld.hidden) continue;
+                        if (!fld || fld.hidden) continue;
                         if (str.indexOf(sdata.value) == -1) str.push(sdata.value);
                     }
                     if (str.length > 0) $(obj.box).find('.w2ui-grid-data > div').w2marker(str);


### PR DESCRIPTION
Do not crash if obj.searchData[] contains en extry not defined in
obj.searches[].