### PR TITLE
Daggetlover add headers data 1

### DIFF
--- a/src/w2form.js
+++ b/src/w2form.js
@@ -1,4 +1,7 @@
 /************************************************************************
+* 
+* modified crk version for HTTP headers this is a 1.5 module
+* 
 *   Library: Web 2.0 UI for jQuery (using prototypical inheritance)
 *   - Following objects defined
 *        - w2form      - form widget
@@ -47,6 +50,7 @@
         this.original  = {};
         this.postData  = {};
         this.toolbar   = {};       // if not empty, then it is toolbar
+        this.headersData = {};
         this.tabs      = {};       // if not empty, then it is tabs object
 
         this.style         = '';
@@ -75,9 +79,10 @@
             var fields   = method.fields;
             var toolbar  = method.toolbar;
             var tabs     = method.tabs;
+            var headersData  = method.headersData;
             // extend items
             var object = new w2form(method);
-            $.extend(object, { record: {}, original: {}, fields: [], tabs: {}, toolbar: {}, handlers: [] });
+            $.extend(object, { record: {}, original: {}, fields: [], tabs: {}, toolbar: {}, handlers: [], headersData: {} });
             if ($.isArray(tabs)) {
                 $.extend(true, object.tabs, { tabs: [] });
                 for (var t = 0; t < tabs.length; t++) {
@@ -88,6 +93,7 @@
                 $.extend(true, object.tabs, tabs);
             }
             $.extend(true, object.toolbar, toolbar);
+            $.extend(true, object.headersData, headersData);
             // reassign variables
             if (fields) for (var p = 0; p < fields.length; p++) {
                 var field = $.extend(true, {}, fields[p]);
@@ -303,12 +309,12 @@
                     }
                 };
             }
-            w2utils.message.call(this, {
-                box   : this.box,
-                path  : 'w2ui.' + this.name,
-                title : '.w2ui-form-header:visible',
-                body  : '.w2ui-form-box'
-            }, options);
+            //w2utils.message.call(this, {
+            //    box   : this.box,
+            //    path  : 'w2ui.' + this.name,
+            //    title : '.w2ui-form-header:visible',
+            //    body  : '.w2ui-form-box'
+            //}, options);
         },
 
         validate: function (showErrors) {
@@ -436,7 +442,7 @@
             $.extend(params, this.postData);
             $.extend(params, postData);
             // event before
-            var edata = this.trigger({ phase: 'before', type: 'request', target: this.name, url: this.url, postData: params });
+            var edata = this.trigger({ phase: 'before', type: 'request', target: this.name, url: this.url, postData: params, headersData: params });
             if (edata.isCancelled === true) { if (typeof callBack == 'function') callBack({ status: 'error', message: 'Request aborted.' }); return; }
             // default action
             this.record   = {};
@@ -459,6 +465,7 @@
             var ajaxOptions = {
                 type     : 'POST',
                 url      : url,
+                headers  : edata.headersData,
                 data     : edata.postData,
                 dataType : 'text'   // expected from server
             };
@@ -597,7 +604,7 @@
                 });
                 params.record = $.extend(true, {}, obj.record);
                 // event before
-                var edata = obj.trigger({ phase: 'before', type: 'submit', target: obj.name, url: obj.url, postData: params });
+                var edata = obj.trigger({ phase: 'before', type: 'submit', target: obj.name, url: obj.url, headersData: obj.headersData, postData: params });
                 if (edata.isCancelled === true) return;
                 // default action
                 var url = edata.url;
@@ -616,6 +623,7 @@
                 var ajaxOptions = {
                     type     : 'POST',
                     url      : url,
+                    headers  : edata.headersData,
                     data     : edata.postData,
                     dataType : 'text',   // expected from server
                     xhr : function() {
@@ -1279,3 +1287,6 @@
     $.extend(w2form.prototype, w2utils.event);
     w2obj.form = w2form;
 })(jQuery);
+
+
+

--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -127,6 +127,7 @@
         this.searchData   = [];
         this.sortData     = [];
         this.postData     = {};
+        this.httpHdrData  = {};
         this.toolbar      = {};       // if not empty object; then it is toolbar object
 
         this.show = {
@@ -233,10 +234,11 @@
             var searchData   = method.searchData;
             var sortData     = method.sortData;
             var postData     = method.postData;
-            var toolbar      = method.toolbar;
+            var httpHdrData  = method.httpHdrData;
+	    var toolbar      = method.toolbar;
             // extend items
             var object = new w2grid(method);
-            $.extend(object, { postData: {}, records: [], columns: [], searches: [], toolbar: {}, sortData: [], searchData: [], handlers: [] });
+            $.extend(object, { postData: {},  httpHdrData: {}, records: [], columns: [], searches: [], toolbar: {}, sortData: [], searchData: [], handlers: [] });
             if (object.onExpand != null) object.show.expandColumn = true;
             $.extend(true, object.toolbar, toolbar);
             // reassign variables
@@ -246,6 +248,7 @@
             if (searchData)   for (var p = 0; p < searchData.length; p++)   object.searchData[p]    = $.extend(true, {}, searchData[p]);
             if (sortData)     for (var p = 0; p < sortData.length; p++)     object.sortData[p]      = $.extend(true, {}, sortData[p]);
             object.postData = $.extend(true, {}, postData);
+	    object.httpHdrData = $.extend(true, {}, httpHdrData);
 
             // check if there are records without recid
             if (records) for (var r = 0; r < records.length; r++) {
@@ -2158,13 +2161,14 @@
             }
             // append other params
             $.extend(params, this.postData);
+            $.extend(params, this.httpHdrData);
             $.extend(params, add_params);
             // event before
             if (cmd == 'get') {
-                var edata = this.trigger({ phase: 'before', type: 'request', target: this.name, url: url, postData: params });
+                var edata = this.trigger({ phase: 'before', type: 'request', target: this.name, url: url, postData: params, httpHdrData: params });
                 if (edata.isCancelled === true) { if (typeof callBack == 'function') callBack({ status: 'error', message: 'Request aborted.' }); return; }
             } else {
-                var edata = { url: url, postData: params };
+                var edata = { url: url, postData: params, httpHdrData: params };
             }
             // call server to get data
             var obj = this;
@@ -2198,6 +2202,7 @@
                 type     : 'POST',
                 url      : url,
                 data     : edata.postData,
+                headers  : edata.httpHdrData,
                 dataType : 'text'  // expected data type from server
             };
             if (w2utils.settings.dataType == 'HTTP') {

--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -1,4 +1,7 @@
 /************************************************************************
+* 
+* modified crk version for HTTP headers this is a 1.5 module
+* 
 *   Library: Web 2.0 UI for jQuery (using prototypical inheritance)
 *   - Following objects defined
 *        - w2grid        - grid widget
@@ -127,7 +130,7 @@
         this.searchData   = [];
         this.sortData     = [];
         this.postData     = {};
-        this.httpHdrData  = {};
+        this.headersData  = {};
         this.toolbar      = {};       // if not empty object; then it is toolbar object
 
         this.show = {
@@ -234,11 +237,11 @@
             var searchData   = method.searchData;
             var sortData     = method.sortData;
             var postData     = method.postData;
-            var httpHdrData  = method.httpHdrData;
+            var headersData  = method.headersData;
 	    var toolbar      = method.toolbar;
             // extend items
             var object = new w2grid(method);
-            $.extend(object, { postData: {},  httpHdrData: {}, records: [], columns: [], searches: [], toolbar: {}, sortData: [], searchData: [], handlers: [] });
+            $.extend(object, { postData: {}, headersData: {}, records: [], columns: [], searches: [], toolbar: {}, sortData: [], searchData: [], handlers: [] });
             if (object.onExpand != null) object.show.expandColumn = true;
             $.extend(true, object.toolbar, toolbar);
             // reassign variables
@@ -248,7 +251,7 @@
             if (searchData)   for (var p = 0; p < searchData.length; p++)   object.searchData[p]    = $.extend(true, {}, searchData[p]);
             if (sortData)     for (var p = 0; p < sortData.length; p++)     object.sortData[p]      = $.extend(true, {}, sortData[p]);
             object.postData = $.extend(true, {}, postData);
-	    object.httpHdrData = $.extend(true, {}, httpHdrData);
+            object.headersData = $.extend(true, {}, headersData);
 
             // check if there are records without recid
             if (records) for (var r = 0; r < records.length; r++) {
@@ -2161,14 +2164,14 @@
             }
             // append other params
             $.extend(params, this.postData);
-            $.extend(params, this.httpHdrData);
+            $.extend(params, this.headersData);
             $.extend(params, add_params);
             // event before
             if (cmd == 'get') {
-                var edata = this.trigger({ phase: 'before', type: 'request', target: this.name, url: url, postData: params, httpHdrData: params });
+                var edata = this.trigger({ phase: 'before', type: 'request', target: this.name, url: url, postData: params, headersData: params });
                 if (edata.isCancelled === true) { if (typeof callBack == 'function') callBack({ status: 'error', message: 'Request aborted.' }); return; }
             } else {
-                var edata = { url: url, postData: params, httpHdrData: params };
+                var edata = { url: url, postData: params, headersData: params };
             }
             // call server to get data
             var obj = this;
@@ -2202,7 +2205,7 @@
                 type     : 'POST',
                 url      : url,
                 data     : edata.postData,
-                headers  : edata.httpHdrData,
+                headers  : edata.headersData,
                 dataType : 'text'  // expected data type from server
             };
             if (w2utils.settings.dataType == 'HTTP') {
@@ -7285,3 +7288,5 @@
     $.extend(w2grid.prototype, w2utils.event);
     w2obj.grid = w2grid;
 })(jQuery);
+
+


### PR DESCRIPTION
w2grid and w2form changes to support adding header data to AJAX requests. Changes are working on my test system. 

Example usage;
	$().w2grid({	
		name: 'gridLaunch',
		url: {
			get: 'launch/grid',
			save : 'launch/create' 
		},
		headersData: {
			'servicekey' : 'A12G95',
			'authtoken' : 'Tok04991'
		},