### PR TITLE
w2grid.js: Make text search type configurable

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -107,6 +107,7 @@
 *   - added noReset option to localSort()
 *   - onColumnSelect
 *   - need to update PHP example
+*   - textSearch: 'begins' (default), 'contains', 'is', ...
 *
 ************************************************************************/
 
@@ -176,6 +177,7 @@
         this.markSearch      = true;
         this.columnTooltip   = 'normal'; // can be normal, top, bottom, left, right
         this.disableCVS      = false;    // disable Column Virtual Scroll
+        this.textSearch      = 'begins'; // default search type for text
 
         this.total   = 0;     // server total
         this.limit   = 100;
@@ -1830,7 +1832,7 @@
                                     var tmp = {
                                         field    : search.field,
                                         type     : search.type,
-                                        operator : (search.operator != null ? search.operator : (search.type == 'text' ? 'begins' : 'is')),
+                                        operator : (search.operator != null ? search.operator : (search.type == 'text' ? this.textSearch : 'is')),
                                         value    : value
                                     };
                                     if ($.trim(value) != '') searchData.push(tmp);
@@ -1874,7 +1876,7 @@
                                 var tmp = {
                                     field    : this.columns[i].field,
                                     type     : 'text',
-                                    operator : 'begins',
+                                    operator : this.textSearch,
                                     value    : value
                                 };
                                 searchData.push(tmp);
@@ -1886,7 +1888,7 @@
                         if (search == null) search = { field: field, type: 'text' };
                         if (search.field == field) this.last.caption = search.caption;
                         if (value !== '') {
-                            var op  = 'begins';
+                            var op  = this.textSearch;
                             var val = value;
                             if (['date', 'time', 'datetime'].indexOf(search.type) != -1) op = 'is';
                             if (['list', 'enum'].indexOf(search.type) != -1) {

--- a/test/grid3.html
+++ b/test/grid3.html
@@ -21,6 +21,7 @@ $(function () {
             selectColumn : false
         },
         selectType: 'cell',
+        textSearch: 'contains',
         columns: [
             { field: 'a', caption: '<div style="text-align: center">A</div>', size: '95px', searchable: true, editable: { type: 'div' }, frozen: true },
             { field: 'b', caption: '<div style="text-align: center">B</div>', size: '95px', editable: { type: 'div' }, frozen: true},


### PR DESCRIPTION
I prefer to have ‘contains’ as default text search type, but there are
other options. Make this configurable with a new ‘textSearch’ grid
property.

No changes to current behaviour.