### PR TITLE
Fix - w2form.render() calls .refresh() twice / popup overview `onKeydown`

### DIFF
--- a/docs/overview/popup.html
+++ b/docs/overview/popup.html
@@ -51,6 +51,6 @@ options: {
     onMax           : null,    // event when maximized
     onMin           : null,    // event when minimized
     onToggle        : null,    // event when maximized/minimized
-    onKeyboard      : null     // event when keyboard button is clicked
+    onKeydown      : null     // event when keyboard button is clicked
 }
 </textarea>

--- a/src/w2form.js
+++ b/src/w2form.js
@@ -1254,9 +1254,7 @@
             var url = (typeof this.url != 'object' ? this.url : this.url.get);
             if (url && this.recid != 0 && this.recid != null) {
                 this.request();
-            } else {
-                this.refresh();
-            }
+            } 
             // attach to resize event
             if ($('.w2ui-layout').length == 0) { // if there is layout, it will send a resize event
                 this.tmp_resize = function (event) { w2ui[obj.name].resize(); };


### PR DESCRIPTION
**w2form.render() calls .refresh() twice:**
1.  In `else`-block  of  `if (url && this.recid != 0 && this.recid != null) { this.request(); }...` - it's redundant call, `else`-block was deleted
2. As intended using  setTimeout()

P.S.  to see bug just add `onRefresh` to any form: 
<code>onRefresh: function(e){
            e.onComplete = function(){console.log(e);};
            }</code>

**Fix popup overview**
There is a mistake in options:
It should be  `onKeydown` instead of `onKeyboard`