### PR TITLE
Fixed error caused by PR #1261

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -5550,7 +5550,7 @@
             frecords.css({ overflow: 'hidden', top: records.css('top') });
             if (this.show.emptyRecords && !bodyOverflowY) {
                 var max      = Math.floor(records.height() / this.recordHeight) - 1;
-                var leftover = records[0].scrollHeight - max * this.recordHeight;
+                if (records[0]) var leftover = records[0].scrollHeight - max * this.recordHeight;
                 if (leftover >= this.recordHeight) {
                     leftover -= this.recordHeight;
                     max++;

--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -5550,7 +5550,8 @@
             frecords.css({ overflow: 'hidden', top: records.css('top') });
             if (this.show.emptyRecords && !bodyOverflowY) {
                 var max      = Math.floor(records.height() / this.recordHeight) - 1;
-                if (records[0]) var leftover = records[0].scrollHeight - max * this.recordHeight;
+                var leftover = 0;
+                if (records[0]) leftover = records[0].scrollHeight - max * this.recordHeight;
                 if (leftover >= this.recordHeight) {
                     leftover -= this.recordHeight;
                     max++;


### PR DESCRIPTION
Fixes a small error in PR #1261. Now makes a check to ensure `records[0]` is not undefined before getting its `scrollHeight`.