### PR TITLE
Grid: make 'editable' selection more flexible 

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -7028,7 +7028,7 @@
             var rec = this.records[ind];
             if (!rec || !col) return null;
             var edit = (rec.w2ui ? rec.w2ui.editable : null);
-            if (edit == false) return null;
+            if (edit === false) return null;
             if (edit == null || edit === true) {
                 edit = (col ? col.editable : null);
                 if (typeof(edit) === 'function') {

--- a/test/grid2.html
+++ b/test/grid2.html
@@ -29,7 +29,7 @@ $(function () {
             toolbar: true,
             footer: true,
             header: true,
-            emptyRecords: true,
+            emptyRecords: false,
             selectColumn: true,
             expandColumn: false,
             columnHeaders: true,
@@ -41,7 +41,11 @@ $(function () {
         // selectType: 'cell',
         columns: [                
             { field: 'recid', caption: 'ID', size: '80px', sortable: true, searchable: 'int', frozen: true },
-            { field: 'int', caption: 'int', size: '80px', sortable: true, resizable: true, editable: { type: 'int', min: 0, max: 100 } },
+            { field: 'int', caption: 'int', size: '80px', sortable: true, resizable: true,
+              editable: function (record, index, col_index, data) {
+                  // only odd 'recid' records are editable
+                  if (record.recid % 2) return { type: 'int', min: 0, max: 100 };
+              } },
             { field: 'money', caption: 'money', size: '80px', sortable: true, resizable: true, editable: { type: 'money' }, render: 'money' },
             { field: 'percent', caption: 'percent', size: '80px', sortable: true, resizable: true, editable: { type: 'percent' }, render: 'percent' },
             { field: 'hex', caption: 'hex', size: '80px', sortable: true, resizable: true, editable: { type: 'hex' } },
@@ -62,7 +66,11 @@ $(function () {
                     return html;
                 }
             },
-            { field: 'check', caption: 'check', size: '40px', sortable: true, resizable: true, editable: { type: 'checkbox' } }
+            { field: 'check', caption: 'check', size: '40px', sortable: true, resizable: true,
+                editable: function (record, index, col_index, data) {
+                  // only odd 'recid' records are editable
+                  if (record.recid % 2) return { type: 'checkbox' }
+               } },
             // { field: 'enum', caption: 'enum', size: '380px', sortable: true, resizable: true, editable: { type: 'enum', items: people } },
             // { field: 'file', caption: 'file', size: '80px', sortable: true, resizable: true, editable: { type: 'file' } },
             // { field: 'radio', caption: 'radio', size: '80px', sortable: true, resizable: true, editable: { type: 'radio' } },


### PR DESCRIPTION
Make it easy to define a cell editor which is different for each cell, not only per-column.

This is done by allowing to optionally define col.editable as a function. In this situation, when w2ui need to check if and how a given cell can be edited, it will call col.editable() with the same parameter than col.render(), and col.editable() shall return null (cell not editable) or an appropriate 'editable' object.

This patch add a 'getCellEditable()' method, with similar argument than getCellValue(). getCellEditable() will look at col.editable and rec.w2ui.editable and return null (cell not editable) or the right 'editable' object descriptor. The grid code is changed to use getCellEditable() consistently everywhere when the "editable" state of a cell is checked.
