### PR TITLE
Complement search terms for enums and list

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -1861,7 +1861,8 @@
                                         || (search.type == 'percent' && w2utils.isFloat(value)) || (search.type == 'hex' && w2utils.isHex(value))
                                         || (search.type == 'currency' && w2utils.isMoney(value)) || (search.type == 'money' && w2utils.isMoney(value))
                                         || (search.type == 'date' && w2utils.isDate(value)) || (search.type == 'time' && w2utils.isTime(value))
-                                        || (search.type == 'datetime' && w2utils.isDateTime(value))
+                                        || (search.type == 'datetime' && w2utils.isDateTime(value)) || (search.type == 'enum' && w2utils.isAlphaNumeric(value)) 
+                                        || (search.type == 'list' && w2utils.isAlphaNumeric(value))
                                     ) {
                                     var tmp = {
                                         field    : search.field,


### PR DESCRIPTION
In a grid, sometimes we have fields that have a numeric value but render a text. Those numeric values normally have an associated description and is convenient to use an enum or a list to select search options for those fields. When the users want to search a value in that column, they will enter the associated text/description. So it is convenient to send the server those fields in the search record when the search term is declared also as enum or list.