### PR TITLE
Update w2grid.js

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -6935,8 +6935,10 @@
                         break;
                     }
                 }
-                for (var i = 0; i < level; i++) {
-                    infoBubble += '<span class="w2ui-show-children w2ui-icon-empty"></span>';
+                if (record.w2ui.parent_recid){
+                        for (var i = 0; i < level; i++) {
+                        infoBubble += '<span class="w2ui-show-children w2ui-icon-empty"></span>';
+                        }
                 }
                 infoBubble += '<span class="w2ui-show-children '+
                         (record.w2ui.children.length > 0


### PR DESCRIPTION
Fix: Prevent parent row from adding indentions when children rows are being expanded