### PR TITLE
Made w2utils locale accept optional caching parameter

### DIFF
--- a/src/w2utils.js
+++ b/src/w2utils.js
@@ -1452,9 +1452,12 @@ var w2utils = (function ($) {
         if (translation == null) return phrase; else return translation;
     }
 
-    function locale (locale) {
+    function locale (locale, cache) {
         if (!locale) locale = 'en-us';
-
+        if (typeof (cache) === 'undefined') {
+            cache = false;   
+        }
+        
         // if the locale is an object, not a string, than we assume it's a
         if(typeof locale !== "string" ) {
             w2utils.settings = $.extend(true, w2utils.settings, locale);
@@ -1472,7 +1475,7 @@ var w2utils = (function ($) {
             type     : "GET",
             dataType : "JSON",
             async    : false,
-            cache    : false,
+            cache    : cache,
             success  : function (data, status, xhr) {
                 w2utils.settings = $.extend(true, w2utils.settings, data);
             },


### PR DESCRIPTION
Hey everyone,

first of all, thanks for this great project, I really like it very much.
I use it for displaying grid selections in Microsoft Dynamics CRM and it works great.
Unfortunately, when loading translations, the AJAX request automatically appends a query string to the locale URL, if cache is false on the request.
Dynamics CRM does not allow custom query strings on web resources, thus I can not use it like this.
By being able to turn on caching on this particular request, I can get translations to work.
I would be glad if you could include this PR, as this should also not be a breaking change.

Kind Regards,
Florian