### PR TITLE
Adding "hidecheckbox" property to a w2grid record

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -6916,7 +6916,7 @@
             if (this.show.selectColumn) {
                 rec_html1 +=
                         '<td id="grid_'+ this.name +'_cell_'+ ind +'_select' + (summary ? '_s' : '') + '" class="w2ui-grid-data w2ui-col-select">'+
-                            (summary !== true ?
+                            (summary !== true  && !record.w2ui.hidecheckbox ?
                             '    <div>'+
                             '        <input class="w2ui-grid-select-check" type="checkbox" tabindex="-1" '+
                                         (isRowSelected ? 'checked="checked"' : '') + ' style="pointer-events: none"/>'+

--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -6916,7 +6916,7 @@
             if (this.show.selectColumn) {
                 rec_html1 +=
                         '<td id="grid_'+ this.name +'_cell_'+ ind +'_select' + (summary ? '_s' : '') + '" class="w2ui-grid-data w2ui-col-select">'+
-                            (summary !== true  && !record.w2ui.hidecheckbox ?
+                            (summary !== true  && (!record.hasOwnProperty('w2ui') || !record.w2ui.hasOwnProperty('hidecheckbox') || !record.w2ui.hidecheckbox) ?
                             '    <div>'+
                             '        <input class="w2ui-grid-select-check" type="checkbox" tabindex="-1" '+
                                         (isRowSelected ? 'checked="checked"' : '') + ' style="pointer-events: none"/>'+


### PR DESCRIPTION
This property will hide checkbox in record in grid with selectColumn. If w2ui.GRID.records[N].w2ui.hidecheckbox set true the checkbox in this row will be hidden. It's helpful when the row has subgrid or childern records (in a tree-like grid) and need to allow to select only start branches of tree.