### PR TITLE
Refactor code to easily override copy/paste functionality

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -4054,7 +4054,7 @@
                     for (var c = minCol; c <= maxCol; c++) {
                         var col = this.columns[c];
                         if (col.hidden === true) continue;
-                        text += w2utils.stripTags(this.getCellHTML(ind, c)) + '\t';
+                        text += this.getCellCopy(ind, c) + '\t';
                     }
                     text = text.substr(0, text.length-1); // remove last \t
                     text += '\n';
@@ -4076,7 +4076,7 @@
                     for (var c = 0; c < this.columns.length; c++) {
                         var col = this.columns[c];
                         if (col.hidden === true) continue;
-                        text += '"' + w2utils.stripTags(this.getCellHTML(ind, c)) + '"\t';
+                        text += '"' + this.getCellCopy(ind, c) + '"\t';
                     }
                     text = text.substr(0, text.length-1); // remove last \t
                     text += '\n';
@@ -4104,6 +4104,16 @@
             }
         },
 
+        /**
+         * Gets value to be copied to the clipboard
+         * @param ind index of the record
+         * @param col_ind index of the column
+         * @returns the displayed value of the field's record associated with the cell
+         */
+        getCellCopy: function(ind, col_ind) {
+            return w2utils.stripTags(this.getCellHTML(ind, col_ind));
+        },
+
         paste: function (text) {
             var sel = this.getSelection();
             var ind = this.get(sel[0].recid, true);
@@ -4129,10 +4139,7 @@
                 if (rec == null) continue;
                 for (var dt = 0; dt < tmp.length; dt++) {
                     if (!this.columns[col + cnt]) continue;
-                    var field = this.columns[col + cnt].field;
-                    rec.w2ui = rec.w2ui || {};
-                    rec.w2ui.changes = rec.w2ui.changes || {};
-                    rec.w2ui.changes[field] = tmp[dt];
+                    this.setCellPaste(rec, col + cnt, tmp[dt]);
                     cols.push(col + cnt);
                     cnt++;
                 }
@@ -4144,6 +4151,19 @@
             this.refresh();
             // event after
             this.trigger($.extend(edata, { phase: 'after' }));
+        },
+
+        /**
+         * Sets record field using clipboard text
+         * @param rec record
+         * @param col_ind column index
+         * @param paste sub part of the pasted text
+         */
+        setCellPaste: function(rec, col_ind, paste) {
+            var field = this.columns[col_ind].field;
+            rec.w2ui = rec.w2ui || {};
+            rec.w2ui.changes = rec.w2ui.changes || {};
+            rec.w2ui.changes[field] = paste;
         },
 
         // ==================================================


### PR DESCRIPTION
As seen in https://github.com/vitmalina/w2ui/issues/1560 the copy/past functionality can be improve.

In order to custom the copy/paste functionality, refactor copy/paste fonctions to easier override copy/paste cell

For example if we want to copy and paste adding a pipe in case that the value is coming from list :
```
/**
 * Get the internal value of a cell
 * @param ind index of the record
 * @param col_ind index of the column
 * @returns the value of the field's record associated with the cell
 */
w2ui.grid.getCellCopy = function (ind, col_ind) {
    var col = w2ui.grid.columns[col_ind];
    var record = w2ui.grid.records[ind];

    var data = record[col.field];
    if (record && record.w2ui && record.w2ui.changes && record.w2ui.changes[col.field] != null) {
        data = record.w2ui.changes[col.field];
    }

    if ($.isPlainObject(data)){
        var copy = data.id;
        if(data.text) copy+='|'+data.text;
        return copy; //return data.id;
    } else {
        return data;
    }
};

/**
 * Copy cell. If the cells contains a pipe, then it will be understand as an array [id,text].
 * If the value copied is the same, do not copy
 * @param rec current record
 * @param col_ind id of the column
 * @param paste sub part of the text pasted corresponding to a cell
 */
w2ui.grid.setCellPaste = function (rec, col_ind, paste) {
    var field = w2ui.grid.columns[col_ind].field;
    rec.w2ui = rec.w2ui || {};
    rec.w2ui.changes = rec.w2ui.changes || {};
    var indexOfPipe = paste.indexOf('|');
    if(indexOfPipe == -1) {
        if(rec[field] !== paste)
            rec.w2ui.changes[field] = paste;
    } else {
        var id = paste.substr(0, indexOfPipe);
        var text = paste.substr(indexOfPipe+1);
        //if new record or the value has changed
        if(rec[field] == undefined || rec[field].id != id && rec[field].text != text) {
            rec.w2ui.changes[field] = {id: id, text: text};
        }
    }
};
```
Note that I didn't commit the copy/paste functionality with pipe because it's not generic and safe : if the csv/excel file contains pipe, the system won't work as expected. 