### PR TITLE
remove all bonded events on the box during destroy

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -4997,8 +4997,8 @@
             // event before
             var edata = this.trigger({ phase: 'before', target: this.name, type: 'destroy' });
             if (edata.isCancelled === true) return;
-            // remove events
-            $(window).off('resize.w2ui-'+ this.name);
+            // remove all events
+            $(this.box).off();
             // clean up
             if (typeof this.toolbar == 'object' && this.toolbar.destroy) this.toolbar.destroy();
             if ($(this.box).find('#grid_'+ this.name +'_body').length > 0) {


### PR DESCRIPTION
remove events bonded on the box like mouseup and mousedown created in initColumnDrag

Issue faced: When I recreated another grid on the same DOM, the events binded again, causing multiple event being called. 