### PR TITLE
UPDATE: gracefully handle empty arrays passed as null

### DIFF
--- a/src/w2fields.js
+++ b/src/w2fields.js
@@ -1460,6 +1460,7 @@
                                 data.records = data.items;
                                 delete data.items;
                             }
+                            if (data.status == 'success' && data.records == null) { data.records = []; } // handles Golang marshal of empty arrays to null
                             if (data.status != 'success' || !Array.isArray(data.records)) {
                                 console.log('ERROR: server did not return proper structure. It should return', { status: 'success', records: [{ id: 1, text: 'item' }] });
                                 return;


### PR DESCRIPTION
By default, Golang's json marshaller emits the following for a result with no matching records:
  {"status":"success","total":0,"records":null}
In a previous pull request I supplied a fix for this used by the grid.  I have encountered this problem recently on enum lists where the server sends down matches as the user types.  I've been using this fix for a while and it works nicely.