### PR TITLE
bugfix find() method - return array of record objects

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -474,7 +474,7 @@
                     }
                 }
                 if (match && returnIndex !== true) recs.push(this.records[i].recid);
-                if (match && returnIndex === true) recs.push(i);
+                if (match && returnIndex === true) recs.push(this.records[i]);
             }
             return recs;
         },


### PR DESCRIPTION
Bug in w2grid.find metod:
Returns array of ints when returnIndex set to true, instead array of record objects.