### PR TITLE
Fix issue #1553

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -5185,7 +5185,7 @@
 
                     //start event for drag start
                     _dragData.columnHead = origColumn = $( event.originalEvent.target ).parents( '.w2ui-head' );
-                    origColumnNumber = parseInt( origColumn.attr( 'col' ), 10);
+                    _dragData.originalPos = origColumnNumber = parseInt( origColumn.attr( 'col' ), 10);
                     edata = obj.trigger({ type: 'columnDragStart', phase: 'before', originalEvent: event, origColumnNumber: origColumnNumber, target: origColumn[0] });
                     if ( edata.isCancelled === true ) return false;
 
@@ -5195,7 +5195,6 @@
                     $( document ).on( 'mouseup', dragColEnd );
                     $( document ).on( 'mousemove', dragColOver );
 
-                    _dragData.originalPos = parseInt( $( event.originalEvent.target ).parent( '.w2ui-head' ).attr( 'col' ), 10 );
                     //_dragData.columns.css({ overflow: 'visible' }).children( 'div' ).css({ overflow: 'visible' });
 
                     //configure and style ghost image


### PR DESCRIPTION
Fixed the issue #1553  where the last column disappear after reordering columns, when column header's caption contains html.

It was caused by always assuming that the parent was the column head which will not always be if the caption has one or more html nodes, and thus it couldn't get the correct position, which made the last column disappear.

_Link to issue: https://github.com/vitmalina/w2ui/issues/1553_