### PR TITLE
Add the height of title bar to the popup height

### DIFF
--- a/src/w2popup.js
+++ b/src/w2popup.js
@@ -64,7 +64,9 @@ var w2popup = {};
                 dlgOptions['body']  = $(this).html();
             }
             if (parseInt($(this).css('width')) !== 0)  dlgOptions['width']  = parseInt($(this).css('width'));
-            if (parseInt($(this).css('height')) !== 0) dlgOptions['height'] = parseInt($(this).css('height'));
+            //if the popup will have a title bar, we must add the height of title bar to the popup height
+            var hasTitlebar = options.title || (options.showClose || options.showClose === undefined) || (options.showMax || options.showMax === undefined) ;
+            if (parseInt($(this).css('height')) !== 0) dlgOptions['height'] = parseInt($(this).css('height')) + (hasTitlebar?32:0);
         }
         // show popup
         return w2popup[method]($.extend({}, dlgOptions, options));


### PR DESCRIPTION
This is a small hack to handle the height of title in the popup height when compute from contents.

I think that it would be better to do it after popup generation to get the real title bar height instead of hardcoded 32 value because the CSS may have been customized but I think it would be a quite heavy modification in a RC version