### PR TITLE
Fixed move still showing after cancelled event

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -5014,6 +5014,7 @@
                         if (edata.isCancelled === true) {
                             $('#grid_'+ obj.name + '_ghost').remove();
                             obj.refresh();
+                            delete obj.last.move;
                             return;
                         }
                         // default behavior


### PR DESCRIPTION
delete obj.last.move after cancelling event to prevent from move still showing.