### PR TITLE
fix resize priority in w2overlay when the search box is opened

### DIFF
--- a/src/w2utils.js
+++ b/src/w2utils.js
@@ -2475,9 +2475,9 @@ w2utils.event = {
 
         // need time to display
         setTimeout(function () {
-            resize();
             $(document).off('.w2overlay'+ name).on('click.w2overlay'+ name, hide);
             if (typeof options.onShow === 'function') options.onShow();
+            resize();
         }, 10);
 
         monitor();

--- a/src/w2utils.js
+++ b/src/w2utils.js
@@ -2662,11 +2662,6 @@ w2utils.event = {
                 if (overflowY && options.align !== 'both') div2.width(w + w2utils.scrollBarSize() + 2);
             }
             menu.css('overflow-y', 'auto');
-
-            // if outer div is bigger, match the size
-            if (div2.height() < div1.height()) {
-                div2.css('height', div1.height() + 'px');
-            }
         }
     };
 


### PR DESCRIPTION
when the "searches" contains elements of the type "enum" and "resize()" occurs before the "initSearches()", the "height" break down on div in w2ui-overlay-"name"-searchOverlay

![image](https://user-images.githubusercontent.com/36474925/36793160-73cc23be-1cbe-11e8-86bb-45484376236c.png)
