### PR TITLE
Replace outdated linear-gradient syntax

### DIFF
--- a/src/less/src/common.less
+++ b/src/less/src/common.less
@@ -145,7 +145,7 @@ select.w2ui-input {
     border: @input-border;
     -webkit-appearance: none;
     background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAALCAQAAACnzwd+AAAAcklEQVR4AcXMsQFBQQDG4P9tAgC0gJYRQJZgKQMwCqCku6vVAAAA+NJHP4KHOk0aV2pRw61n4BBmyOxKQ8I4ehZeuhd3HTx6DQEGZ7sBfr2OOOOj3Yi43kMKs9sZknofOexqZ8npMygwWZTX51CipP+YA1OiZJbYYg9lAAAAAElFTkSuQmCC'),
-                      -webkit-linear-gradient(top,#FFF 20%,#f6f6f6 50%,#EEE 52%,#f4f4f4 100%);
+                      -webkit-linear-gradient(to bottom,#FFF 20%,#f6f6f6 50%,#EEE 52%,#f4f4f4 100%);
     background-size: 17px 6px, 100% 100%;
     background-position: right center, left top;
     background-repeat: no-repeat, no-repeat;

--- a/src/less/src/fields.less
+++ b/src/less/src/fields.less
@@ -505,7 +505,7 @@
     background-image: @a, -moz-linear-gradient(top, @b @c,@d @e,@f @g,@h @i);
     background-image: @a, -ms-linear-gradient(top, @b @c,@d @e,@f @g,@h @i);
     background-image: @a, -o-linear-gradient(top, @b @c,@d @e,@f @g,@h @i);
-    background-image: @a, linear-gradient(top, @b @c,@d @e,@f @g,@h @i);
+    background-image: @a, linear-gradient(to bottom, @b @c,@d @e,@f @g,@h @i);
 }
 
 .w2ui-select {

--- a/src/less/src/mixins.less
+++ b/src/less/src/mixins.less
@@ -98,7 +98,7 @@
     background-image :       -moz-linear-gradient(top, fadeout(@color, 90%) 0%, @color 40%, @color 60%, fadeout(@color, 90%) 100%);
     background-image :        -ms-linear-gradient(top, fadeout(@color, 90%) 0%, @color 40%, @color 60%, fadeout(@color, 90%) 100%);
     background-image :         -o-linear-gradient(top, fadeout(@color, 90%) 0%, @color 40%, @color 60%, fadeout(@color, 90%) 100%);
-    background-image :            linear-gradient(top, fadeout(@color, 90%) 0%, @color 40%, @color 60%, fadeout(@color, 90%) 100%);
+    background-image :            linear-gradient(to bottom, fadeout(@color, 90%) 0%, @color 40%, @color 60%, fadeout(@color, 90%) 100%);
     @colorStart: argb(rgba(red(@color), green(@color), blue(@color), 255));
     @colorEnd: argb(rgba(red(@color), green(@color), blue(@color), 255));
     filter: progid:dximagetransform.microsoft.gradient(startColorstr='@{colorStart}', endColorstr='@{colorEnd}', GradientType=0);


### PR DESCRIPTION
I stumbled on some warnings using **w2ui** library with **webpack** and **postcss-loader**:
```
(Emitted value instead of an instance of Error) autoprefixer: .../node_modules/w2ui/src/less/src/fields.less:508:4: Gradient has outdated direction syntax. New syntax is like `to left` instead of `right`.
...
(Emitted value instead of an instance of Error) autoprefixer: .../node_modules/w2ui/src/less/src/mixins.less:101:4: Gradient has outdated direction syntax. New syntax is like `to left` instead of `right`.
```
This pull-request fixes them.