### PR TITLE
Allow clicking inside other overlays which belong to the elements inside this overlay (fixes #1616)

### DIFF
--- a/src/w2utils.js
+++ b/src/w2utils.js
@@ -2501,6 +2501,8 @@ w2utils.event = {
         function hide(event) {
             if (event && event.button !== 0) return; // only for left click button
             var div1 = $('#w2ui-overlay'+ name);
+            // Allow clicking inside other overlays which belong to the elements inside this overlay
+            if (event && $($(event.target).closest('.w2ui-overlay').data('element')).closest('.w2ui-overlay')[0] === div1[0]) return;
             if (div1.data('keepOpen') === true) {
                 div1.removeData('keepOpen');
                 return;


### PR DESCRIPTION
This prevents overlays from being closed when clicking in another overlay, provided the other overlay belongs to an input fields which lies inside the overlay which would normally be closed.

This should fix #1616 and also fix #1725 which apparently is the same.