### PR TITLE
Export main JS and CSS files in package.json for easier usage with 'require'

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "description": "Complete set of JavaScript UI widget for development of data-driven web applications. Includes layout, grid, toolbar, sidebar, tabs, forms, fields, popup, overlay",
   "license": "MIT",
   "repository": "https://github.com/vitmalina/w2ui",
-  "dependencies" : {
+  "dependencies": {
     "jquery": ">=1.9"
   },
+  "main": "dist/w2ui.js",
+  "style": "dist/w2ui.css",
   "devDependencies": {
     "grunt": "~0.4.2",
     "grunt-contrib-clean": "~0.5.0",


### PR DESCRIPTION
Allow for easier usage of the modules in environments like webpack:

With these changes, it will work to simply do `require('w2ui')` (or `import 'w2ui'`) in JS, and `@import '~w2ui'` in CSS.

Note that one also needs to do `Object.assign(window, require('w2ui'))` to make event handlers work, unfortunately. (Note that this would normally still fail to work for popups - to fix that, you also need to merge #1754)

I intentionally did not set the minified versions, because it will be desirable if the surrounding environment minifies the code (if it so wishes - e.g. `webpack -p`).