### PR TITLE
Make w2popup also work in a module environment

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,7 +76,8 @@ module.exports = function (grunt) {
                     'src/w2toolbar.js',
                     'src/w2sidebar.js',
                     'src/w2fields.js',
-                    'src/w2form.js'
+                    'src/w2form.js',
+                    'src/moduleCompat.js' // must be last
                 ],
                 dest: 'dist/w2ui.js'
             },

--- a/src/moduleCompat.js
+++ b/src/moduleCompat.js
@@ -15,4 +15,12 @@
     for (var m in w2ui) {
         global[m] = w2ui[m];
     }
-})(this, { w2ui: w2ui, w2obj: w2obj, w2utils: w2utils, w2popup: w2popup });
+})(this, {
+    w2ui: w2ui,
+    w2obj: w2obj,
+    w2utils: w2utils,
+    w2popup: w2popup,
+    w2alert: w2alert,
+    w2confirm: w2confirm,
+    w2prompt: w2prompt
+});

--- a/src/moduleCompat.js
+++ b/src/moduleCompat.js
@@ -1,0 +1,18 @@
+/***********************************************************
+*  Compatibility with CommonJS and AMD modules
+*
+*********************************************************/
+
+(function(global, w2ui) {
+    if (typeof define=='function' && define.amd) {
+        return define(function(){ return w2ui; });
+    }
+    if (typeof exports!='undefined') {
+        if (typeof module!='undefined' && module.exports)
+            return exports = module.exports = w2ui;
+        global = exports;
+    }
+    for (var m in w2ui) {
+        global[m] = w2ui[m];
+    }
+})(this, { w2ui: w2ui, w2obj: w2obj, w2utils: w2utils, w2popup: w2popup });

--- a/src/w2utils.js
+++ b/src/w2utils.js
@@ -3323,22 +3323,3 @@ w2utils.event = {
     };
 
 })(jQuery);
-
-/***********************************************************
-*  Compatibility with CommonJS and AMD modules
-*
-*********************************************************/
-
-(function(global, w2ui) {
-    if (typeof define=='function' && define.amd) {
-        return define(function(){ return w2ui; });
-    }
-    if (typeof exports!='undefined') {
-        if (typeof module!='undefined' && module.exports)
-            return exports = module.exports = w2ui;
-        global = exports;
-    }
-    for (var m in w2ui) {
-        global[m] = w2ui[m];
-    }
-})(this, { w2ui: w2ui, w2obj: w2obj, w2utils: w2utils });


### PR DESCRIPTION
Ensure that the `w2popup` object is also exported. Before, only `w2ui`, `w2obj` and `w2utils` were exported.

I moved the module export part to its own file which is included last, instead of adding it to `w2utils`, because a) I think it doesn't really belongs to the utils file and b) It wouldn't be able to export `w2popup` which is declared in another file later on (it would export it as `undefined`).