### PR TITLE
Fix "grid reloads after skip and scroll to end"

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -2572,7 +2572,7 @@
                                 this.last.xhr_hasMore = true;
                             } else {
                                 this.last.xhr_hasMore = false;
-                                this.total = this.last.xhr_offset + data.records.length;
+                                this.total = this.offset + this.last.xhr_offset + data.records.length;
                             }
                             if (this.last.xhr_offset === 0) {
                                 this.records = [];


### PR DESCRIPTION
Fix calculation of total in requestComplete when there is an initial offset made with skip(). This fixes #1775.