### PR TITLE
Support using function to render icon in sidebar

### DIFF
--- a/src/w2sidebar.js
+++ b/src/w2sidebar.js
@@ -875,7 +875,13 @@
                     if (nd.selected && !nd.disabled) obj.selected = nd.id;
                     tmp = '';
                     if (img) tmp  = '<div class="w2ui-node-image w2ui-icon '+ img +    (nd.selected && !nd.disabled ? " w2ui-icon-selected" : "") +'"></div>';
-                    if (icon) tmp = '<div class="w2ui-node-image"><span class="'+ icon +'"></span></div>';
+                    if (icon) {
+                        if (typeof icon == 'function') {
+                            tmp = '<div class="w2ui-node-image"><span>' + icon.call(obj, nd) + '</span></div>';
+                        } else {
+                            tmp = '<div class="w2ui-node-image"><span class="'+ icon +'"></span></div>';
+                        }
+                    }
                     var text = nd.text;
                     if (typeof nd.text == 'function') text = nd.text.call(obj, nd);
                     html =  '<div class="w2ui-node w2ui-level-'+ level +' '+ (nd.selected ? 'w2ui-selected' : '') +' '+ (nd.disabled ? 'w2ui-disabled' : '') +'" id="node_'+ nd.id +'" style="'+ (nd.hidden ? 'display: none;' : '') +'"'+


### PR DESCRIPTION
This pull requests adds support for using a function to render icons in the sidebar.
The reason for wanting to do this is to make use of the [FontAwesome 5 API](https://fontawesome.com/how-to-use/with-the-api/setup/getting-started) to render the icon immediately instead of relying on the FontAwesome class observer which can be a bit slow in detecting changes.