### PR TITLE
Upgrade npm dependencies and enble building with nodejs v12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ node_modules/
 /npm-debug.log
 .DAV
 copy_shield.sh
+npm-shrinkwrap.json
+*~

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+# Install npm dependencies and force ttf2woff2 to version 3.0.0 for node12-compatibility.
+#
+
+test -d node_modules && rm -rf node_modules
+test -f npm-shrinkwrap.json && rm -f npm-shrinkwrap.json
+
+cat <<EOF > npm-shrinkwrap.json
+{
+  "name": "w2ui",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "grunt-webfont": {
+      "dev": true,
+      "version": "1.7.2",
+      "dependencies": {
+        "ttf2woff2": {
+          "version": "3.0.0",
+          "from": "~2.0.3"
+        }
+      }
+    }
+  }
+}
+EOF
+
+npm install

--- a/package.json
+++ b/package.json
@@ -6,18 +6,19 @@
   "license": "MIT",
   "repository": "https://github.com/vitmalina/w2ui",
   "dependencies": {
-    "jquery": ">=1.9"
+    "jquery": ">=1.9",
+    "less": "^3.10.1"
   },
   "main": "dist/w2ui.js",
   "style": "dist/w2ui.css",
   "devDependencies": {
-    "grunt": "~0.4.2",
-    "grunt-contrib-clean": "~0.5.0",
-    "grunt-contrib-concat": "~1.0.1",
-    "grunt-contrib-less": "~0.9.0",
-    "grunt-contrib-watch": "~0.5.3",
-    "grunt-shell": "~0.6.4",
-    "grunt-contrib-uglify": "^0.4.0",
-    "grunt-webfont": "^0.4.3"
+    "grunt": "^1.0.4",
+    "grunt-contrib-clean": "^2.0.0",
+    "grunt-contrib-concat": "^1.0.1",
+    "grunt-contrib-less": "^2.0.0",
+    "grunt-contrib-uglify": "^4.0.1",
+    "grunt-contrib-watch": "^1.1.0",
+    "grunt-shell": "^3.0.1",
+    "grunt-webfont": "^1.7.2"
   }
 }


### PR DESCRIPTION
I updated the npm dependencies fixing a lot of security warning from NPM.
Moreover, I added an install.sh script, which should be called instead of 'npm install' and pushes ttf2woff2 to version 3.0.0 in order to work arund this issue: https://github.com/sapegin/grunt-webfont/issues/394
Please note, that it is strongly discouraged to commit npm-shrinkwrap.json files to repos, that's why I came up with a shell script to push a transitive dependency up to the point the original issue is fixed in grunt-webfont.