### PR TITLE
w2field color use rgba for preview

### DIFF
--- a/src/w2fields.js
+++ b/src/w2fields.js
@@ -894,9 +894,13 @@
             if (this.type === 'color') {
                 var color = $(this.el).val();
                 if (color.substr(0, 3).toLowerCase() !== 'rgb') {
-                    color = '#' + color;
-                    var len = $(this.el).val().length
-                    if (len !== 8 && len !== 6 && len !== 3) color = '';
+                    var len = color.length;
+                    if (len !== 8 && len !== 6 && len !== 3) {
+                        color = '';
+                    } else {
+                        var rgb = w2utils.parseColor(color);
+                        color = 'rgba('+ rgb.r +','+ rgb.g +','+ rgb.b +','+ rgb.a +')';
+                    }
                 }
                 $(this.el).next().find('div').css('background-color', color);
                 if ($(this.el).hasClass('has-focus') && $(this.el).data('skipInit') !== true) {


### PR DESCRIPTION
w2field color use rgba for preview.

Before:
![color_before](https://user-images.githubusercontent.com/10152404/107662095-36773200-6c8a-11eb-80ae-91f901f682a0.png)

Now:
![color_now](https://user-images.githubusercontent.com/10152404/107662116-3c6d1300-6c8a-11eb-954a-a8f95caf9844.png)


Nice to have: a checkered background behind the color preview, so the opacity can actually be perceived