### PR TITLE
fix isMoney

### DIFF
--- a/src/w2utils.js
+++ b/src/w2utils.js
@@ -152,6 +152,8 @@ var w2utils = (function ($) {
     }
 
     function isMoney (val) {
+        if (typeof val === 'object' || val === '') return false;
+        if(isFloat(val)) return true;
         var se = w2utils.settings;
         var re = new RegExp('^'+ (se.currencyPrefix ? '\\' + se.currencyPrefix + '?' : '') +
                             '[-+]?'+ (se.currencyPrefix ? '\\' + se.currencyPrefix + '?' : '') +
@@ -159,7 +161,6 @@ var w2utils = (function ($) {
         if (typeof val === 'string') {
             val = val.replace(new RegExp(se.groupSymbol, 'g'), '');
         }
-        if (typeof val === 'object' || val === '') return false;
         return re.test(val);
     }
 


### PR DESCRIPTION
fix isMoney, see issue #1257

the idea is to short-circuit if it's an object or an empty string.
Also, if it "floats", it's a valid money notation.