### PR TITLE
fix: currencyPrecision=0 always falls to 2

### DIFF
--- a/src/w2utils.js
+++ b/src/w2utils.js
@@ -1878,7 +1878,7 @@ w2utils.formatters = {
 
     'money': function (value, params) {
         if (value == null || value === '') return '';
-        var data = w2utils.formatNumber(Number(value), w2utils.settings.currencyPrecision || 2);
+        var data = w2utils.formatNumber(Number(value), w2utils.settings.currencyPrecision);
         return (w2utils.settings.currencyPrefix || '') + data + (w2utils.settings.currencySuffix || '');
     },
 


### PR DESCRIPTION
currencyPrecision=0 setting does not work and it always falls to 2.
w2utils.settings.currencyPrecision is guaranteed to have a default value assigned. so || is not needed here.