### PR TITLE
Fix Columns Re-order problem #708

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -5428,7 +5428,7 @@
 
             var obj = this,
                 _dragData = {};
-                _dragData.lastInt = null;
+                _dragData.lastInt = undefined;
                 _dragData.pressed = false;
                 _dragData.timeout = null;_dragData.columnHead = null;
 


### PR DESCRIPTION
In the initColumnDrag function, initialize _dragData.lastInt to undefined instead of null.

The difference is that when null is used in Math.min(), it is coerced to a Number and treated as zero, similar to the way isNaN(null) returns false. Math.min(null, 10) will return 0, while Math.min(undefined, 10) will return NaN.

That comes into play around the 16th line of the dragColEnd function. If _dragData.lastInt is undefined then targetColumn will be an empty jQuery object with a length property of 0, which will prevent the dragColEnd function from moving the column.

If you actually drag the column and cause the blue column drag marker to appear, then _draData.lastInt will be set to the number of the column you are dragging to, and everything will work as it should.