### PR TITLE
Fixed errors in setTimeout due to hoisting

### DIFF
--- a/src/w2toolbar.js
+++ b/src/w2toolbar.js
@@ -303,7 +303,7 @@
             var items = 0;
             var tmp   = [];
             for (var a = 0; a < arguments.length; a++) {
-                var it = this.get(arguments[a]);
+                let it = this.get(arguments[a]);
                 if (!it || String(arguments[a]).indexOf(':') != -1) continue;
                 // remove overlay
                 if (['menu', 'menu-radio', 'menu-check', 'drop', 'color', 'text-color'].indexOf(it.type) != -1 && it.checked) {


### PR DESCRIPTION
There was a problem with variable scope. Fixed it by replacing `var` with `let`.

The problem seems to have been caused by hoisting within the scope of function `uncheck`: each iteration of loop `for` was actually using the same variable, so after calling `setTimeout`, the value sometimes changes and sometimes also becomes `null`, which would result in errors.

The same problem exists in master branch, so I'll create another pull request for that. Brach "es6" does not have this problem since all `var` expressions were changed into `let`.