### PR TITLE
Fixed errors in setTimeout due to hoisting

### DIFF
--- a/src/w2toolbar.js
+++ b/src/w2toolbar.js
@@ -304,7 +304,7 @@
             var items = 0;
             var tmp   = [];
             for (var a = 0; a < arguments.length; a++) {
-                var it = this.get(arguments[a]);
+                let it = this.get(arguments[a]);
                 if (!it || String(arguments[a]).indexOf(':') != -1) continue;
                 // remove overlay
                 if (['menu', 'menu-radio', 'menu-check', 'drop', 'color', 'text-color'].indexOf(it.type) != -1 && it.checked) {


### PR DESCRIPTION
Uncheck function was producing errors due to hoisting of `var it`. After calling `setTimout`, the `for` loop may continue and value of `it` changes and may even become `null`.

The same fix was done for branch w2ui-1.5 in commit unix786/w2ui@220c4a73 (pull request #1999 ).