### PR TITLE
reorderColumns had two major issues (branch w2ui-1.5)

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -5506,7 +5506,7 @@
                         width: 0,
                         height: 0,
                         margin: 0,
-                        position: 'fixed',
+                        position: 'absolute',
                         zIndex: 999999,
                         opacity: 0
                     }).addClass( '.w2ui-grid-ghost' ).animate({

--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -4965,7 +4965,7 @@
                 });
             // init mouse events for mouse selection
             var edataCol; // event for column select
-            $(this.box).off('mousedown').on('mousedown', mouseStart);
+            $(this.box).off('mousedown', mouseStart).on('mousedown', mouseStart);
             this.updateToolbar()
             // event after
             this.trigger($.extend(edata, { phase: 'after' }));


### PR DESCRIPTION
1. `reorderColumns` stopped working completely after commit 412c7ae. One of the `mousedown` event handlers (`dragColStart`) was being removed in `render` function.
2. ghost image would often fall off-screen because the style property `position` was incorrectly specified as "fixed". The position is actually set using absolute coordinates (using pageX and pageY from mouse events), so I changed the style to `absolute`.

For testing I used "test/grid2.html", but had to enable `reorderColumns` there.

I haven't checked the master branch yet. It may have the same issues as described here. I can create another pull request if needed.