### PR TITLE
Replaced deprecated JQuery methods

### DIFF
--- a/src/w2field.js
+++ b/src/w2field.js
@@ -1517,7 +1517,7 @@ class w2field extends w2event {
                         // default behavior
                         if (status !== 'abort') {
                             let data
-                            try { data = $.parseJSON(xhr.responseText) } catch (e) {}
+                            try { data = JSON.parse(xhr.responseText) } catch (e) {}
                             console.log('ERROR: Server communication failed.',
                                 '\n   EXPECTED:', { status: 'success', records: [{ id: 1, text: 'item' }] },
                                 '\n         OR:', { status: 'error', message: 'error message' },

--- a/src/w2form.js
+++ b/src/w2form.js
@@ -662,7 +662,7 @@ class w2form extends w2event {
                 // default behavior
                 if (status !== 'abort') {
                     let data
-                    try { data = typeof xhr.responseJSON === 'object' ? xhr.responseJSON : $.parseJSON(xhr.responseText) } catch (e) {}
+                    try { data = typeof xhr.responseJSON === 'object' ? xhr.responseJSON : JSON.parse(xhr.responseText) } catch (e) {}
                     console.log('ERROR: Server communication failed.',
                         '\n   EXPECTED:', { status: 'success', items: [{ id: 1, text: 'item' }] },
                         '\n         OR:', { status: 'error', message: 'error message' },

--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -959,9 +959,9 @@ class w2grid extends w2event {
                 bb = String(bb)
             // do case-insensitive string comparison
             if (typeof aa == 'string')
-                aa = $.trim(aa.toLowerCase())
+                aa = aa.toLowerCase().trim()
             if (typeof bb == 'string')
-                bb = $.trim(bb.toLowerCase())
+                bb = bb.toLowerCase().trim()
 
             switch (sortMode) {
                 case 'natural':
@@ -2020,11 +2020,11 @@ class w2grid extends w2event {
                                     operator : (search.operator != null ? search.operator : (search.type == 'text' ? this.textSearch : 'is')),
                                     value    : value
                                 }
-                                if ($.trim(value) != '') searchData.push(tmp)
+                                if (String(value).trim() != '') searchData.push(tmp)
                             }
                             // range in global search box
-                            if (['int', 'float', 'money', 'currency', 'percent'].indexOf(search.type) != -1 && $.trim(String(value)).split('-').length == 2) {
-                                let t   = $.trim(String(value)).split('-')
+                            if (['int', 'float', 'money', 'currency', 'percent'].indexOf(search.type) != -1 && String(value).trim().split('-').length == 2) {
+                                let t   = String(value).trim().split('-')
                                 let tmp = {
                                     field    : search.field,
                                     type     : search.type,
@@ -2542,7 +2542,7 @@ class w2grid extends w2event {
                 // default behavior
                 if (status != 'abort') { // it can be aborted by the grid itself
                     let data
-                    try { data = typeof xhr.responseJSON === 'object' ? xhr.responseJSON : $.parseJSON(xhr.responseText) } catch (e) {}
+                    try { data = typeof xhr.responseJSON === 'object' ? xhr.responseJSON : JSON.parse(xhr.responseText) } catch (e) {}
                     console.log('ERROR: Server communication failed.',
                         '\n   EXPECTED:', { status: 'success', total: 5, records: [{ recid: 1, field: 'value' }] },
                         '\n         OR:', { status: 'error', message: 'error message' },
@@ -5440,7 +5440,7 @@ class w2grid extends w2event {
                     opacity: 0
                 }).addClass('.w2ui-grid-ghost').animate({
                     width: selectedCol.width(),
-                    height: $(obj.box).find('.w2ui-grid-body:first').height(),
+                    height: $(obj.box).find('.w2ui-grid-body').first().height(),
                     left : event.pageX,
                     top : event.pageY,
                     opacity: 0.8
@@ -7434,11 +7434,11 @@ class w2grid extends w2event {
             if (typeof col.render == 'function') {
                 let html = col.render.call(this, record, ind, col_ind, data)
                 if (html != null && typeof html == 'object') {
-                    data     = $.trim(html.html || '')
+                    data     = (html.html || '').trim()
                     addClass = html.class || ''
                     addStyle = html.style || ''
                 } else {
-                    data = $.trim(html)
+                    data = (html || '').trim()
                 }
                 if (data.length < 4 || data.substr(0, 4).toLowerCase() != '<div') {
                     data = '<div style="'+ style +'" title="'+ getTitle(data) +'">' + infoBubble + String(data) + '</div>'
@@ -7771,7 +7771,7 @@ class w2grid extends w2event {
                 return
             }
             try {
-                let savedState = $.parseJSON(localStorage.w2ui || '{}')
+                let savedState = JSON.parse(localStorage.w2ui || '{}')
                 if (!savedState) savedState = {}
                 if (!savedState.states) savedState.states = {}
                 savedState.states[(this.stateId || this.name)] = state
@@ -7792,7 +7792,7 @@ class w2grid extends w2event {
             // read it from local storage
             try {
                 if (!w2utils.hasLocalStorage) return false
-                let tmp = $.parseJSON(localStorage.w2ui || '{}')
+                let tmp = JSON.parse(localStorage.w2ui || '{}')
                 if (!tmp) tmp = {}
                 if (!tmp.states) tmp.states = {}
                 newState = tmp.states[(this.stateId || this.name)]
@@ -7848,7 +7848,7 @@ class w2grid extends w2event {
         // remove from local storage
         if (w2utils.hasLocalStorage) {
             try {
-                let tmp = $.parseJSON(localStorage.w2ui || '{}')
+                let tmp = JSON.parse(localStorage.w2ui || '{}')
                 if (tmp.states && tmp.states[(this.stateId || this.name)]) {
                     delete tmp.states[(this.stateId || this.name)]
                 }

--- a/src/w2popup.js
+++ b/src/w2popup.js
@@ -617,7 +617,7 @@ class w2dialog extends w2event {
             }
 
             // remove message
-            if ($.trim(options.html) === '' && $.trim(options.body) === '' && $.trim(options.buttons) === '') {
+            if ((options.html || '').trim() === '' && (options.body || '').trim() === '' && (options.buttons || '').trim() === '') {
                 let $msg = $('#w2ui-popup .w2ui-message').last()
                 if (options.msgId != null) {
                     $msg = $('#w2ui-message'+ options.msgId)
@@ -649,7 +649,7 @@ class w2dialog extends w2event {
                     resolve(edata)
                 }, 150)
             } else {
-                if ($.trim(options.body) !== '' || $.trim(options.buttons) !== '') {
+                if ((options.body || '').trim() !== '' || (options.buttons || '').trim() !== '') {
                     options.html = '<div class="w2ui-message-body">'+ options.body +'</div>'+
                         '<div class="w2ui-message-buttons">'+ options.buttons +'</div>'
                 }

--- a/src/w2utils.js
+++ b/src/w2utils.js
@@ -227,8 +227,7 @@ let w2utils = (($) => {
         pm       = val.indexOf('PM') >= 0
         let ampm = (pm || am)
         if (ampm) max = 12; else max = 24
-        val = val.replace('AM', '').replace('PM', '')
-        val = $.trim(val)
+        val = val.replace('AM', '').replace('PM', '').trim()
         // ---
         let tmp = val.split(':')
         let h   = parseInt(tmp[0] || 0), m = parseInt(tmp[1] || 0), s = parseInt(tmp[2] || 0)
@@ -1169,7 +1168,7 @@ let w2utils = (($) => {
         }
         let msgCount = $(where.box).find('.w2ui-message').length
         // remove message
-        if ($.trim(options.html) === '' && $.trim(options.body) === '' && $.trim(options.buttons) === '') {
+        if ((options.html || '').trim() === '' && (options.body || '').trim() === '' && (options.buttons || '').trim() === '') {
             if (msgCount === 0) return // no messages at all
             let $msg = $(where.box).find('#w2ui-message'+ (msgCount-1))
             options  = $msg.data('options') || {}
@@ -1194,7 +1193,7 @@ let w2utils = (($) => {
 
         } else {
 
-            if ($.trim(options.body) !== '' || $.trim(options.buttons) !== '') {
+            if ((options.body || '').trim() !== '' || (options.buttons || '').trim() !== '') {
                 options.html = '<div class="w2ui-message-body">'+ (options.body || '') +'</div>'+
                     '<div class="w2ui-message-buttons">'+ (options.buttons || '') +'</div>'
             }


### PR DESCRIPTION
$.parseJSON is deprecated, use JSON.parse instead

$.trim is deprecated, use the native String.prototype.trim method instead.