### PR TITLE
Make it possible to disable automatic cursor advance after making an inline edit

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -262,6 +262,7 @@ class w2grid extends w2event {
         this.method            = null // if defined, then overwrites ajax method
         this.dataType          = null // if defined, then overwrites w2utils.settings.dataType
         this.parser            = null
+        this.advanceOnEdit     = true // automatically begin editing the next cell after submitting an inline edit?
 
         // these column properties will be saved in stateSave()
         this.stateColProps = {
@@ -2801,16 +2802,18 @@ class w2grid extends w2event {
                 column = this.last._edit.column
                 recid  = this.last._edit.recid
                 this.editChange({ type: 'custom', value: this.last._edit.value }, this.get(recid, true), column, event)
-                let next = event.shiftKey ? this.prevRow(index, column) : this.nextRow(index, column)
-                if (next != null && next != index) {
-                    setTimeout(() => {
-                        if (this.selectType != 'row') {
-                            this.selectNone()
-                            this.select({ recid: this.records[next].recid, column: column })
-                        } else {
-                            this.editField(this.records[next].recid, column, null, event)
-                        }
-                    }, 1)
+                if(this.advanceOnEdit) {
+                    let next = event.shiftKey ? this.prevRow(index, column) : this.nextRow(index, column)
+                    if (next != null && next != index) {
+                        setTimeout(() => {
+                            if (this.selectType != 'row') {
+                                this.selectNone()
+                                this.select({ recid: this.records[next].recid, column: column })
+                            } else {
+                                this.editField(this.records[next].recid, column, null, event)
+                            }
+                        }, 1)
+                    }
                 }
                 this.last.inEditMode = false
             } else {
@@ -3049,16 +3052,18 @@ class w2grid extends w2event {
                             }
                             case 13: { // enter
                                 el.blur()
-                                let next = event.shiftKey ? obj.prevRow(index, column) : obj.nextRow(index, column)
-                                if (next != null && next != index) {
-                                    setTimeout(() => {
-                                        if (obj.selectType != 'row') {
-                                            obj.selectNone()
-                                            obj.select({ recid: obj.records[next].recid, column: column })
-                                        } else {
-                                            obj.editField(obj.records[next].recid, column, null, event)
-                                        }
-                                    }, 1)
+                                if(obj.advanceOnEdit) {
+                                    let next = event.shiftKey ? obj.prevRow(index, column) : obj.nextRow(index, column)
+                                    if (next != null && next != index) {
+                                        setTimeout(() => {
+                                            if (obj.selectType != 'row') {
+                                                obj.selectNone()
+                                                obj.select({ recid: obj.records[next].recid, column: column })
+                                            } else {
+                                                obj.editField(obj.records[next].recid, column, null, event)
+                                            }
+                                        }, 1)
+                                    }
                                 }
                                 if (el.tagName.toUpperCase() == 'DIV') {
                                     event.preventDefault()


### PR DESCRIPTION
I mentioned as a side note in bug report #2024 that I would like to prevent the behavior whereby, when enter is pressed to submit an inline edit, the "edit cursor" automatically advances to another editable cell and opens an inline editor for that cell.

I couldn't find an option whereby I might disable this behavior, so I attempted to introduce one. I've called the option `advanceOnEdit`, and it is set to `true` by default to preserve existing behavior. My code changes check this setting in two places; I'm not sure whether I've caught all necessary places where the check should be made, so please review.