### PR TITLE
w2utils.unescapeId

### DIFF
--- a/src/w2utils.js
+++ b/src/w2utils.js
@@ -15,6 +15,7 @@
 *   - normMenu
 *   - w2utils.message - return a promise
 *   - bindEvents - common method to avoid inline events
+*   - unescapeId
 *
 ************************************************/
 import { w2event } from './w2event.js'
@@ -55,6 +56,7 @@ let w2utils = (($) => {
         encodeTags,
         decodeTags,
         escapeId,
+        unescapeId,
         normMenu,
         bindEvents,
         base64encode,
@@ -549,7 +551,13 @@ let w2utils = (($) => {
 
     function escapeId (id) {
         if (id === '' || id == null) return ''
-        return String(id).replace(/([;&,\.\+\*\~'`:"\!\^#$%@\[\]\(\)=<>\|\/? {}\\])/g, '\\$1')
+        return $.escapeSelector(id)
+        // return String(id).replace(/([;&,\.\+\*\~'`:"\!\^#$%@\[\]\(\)=<>\|\/? {}\\])/g, '\\$1')
+    }
+
+    function unescapeId (id) {
+        if (id === '' || id == null) return ''
+        return $.find.selectors.preFilter.ATTR([null, id])[1]
     }
 
     function base64encode (input) {


### PR DESCRIPTION
Added unescapeId() to w2utils, as requested in #1715

Since w2ui uses JQuery anyway, I've changed w2utils.escapeId() to call $.escapeSelector() instead.

You can test both methods like this:

    const s = String.raw`/([;&,\.\+\*\~'\`:"\!\^#$%@\[\]\(\)=<>\|\/? {}\\])/`
    w2utils.unescapeId( w2utils.escapeId(s) ) === s