### PR TITLE
Fixed name checking

### DIFF
--- a/src/w2event.js
+++ b/src/w2event.js
@@ -10,7 +10,7 @@ class w2event {
     constructor(name) {
         this.handlers = []
         // register globally
-        if (name) {
+        if (typeof name !== 'undefined') {
             window.w2ui = window.w2ui || {}
             if (!w2utils.checkName(name)) return
             window.w2ui[name] = this


### PR DESCRIPTION
The check ``if (name)`` would allow grids (and other w2ui objects) with the names ``false, 0, null, undefined, ""`` to be created without an error message and without being registered to the global ``w2ui`` object.