### PR TITLE
Do not change grid.total if it's -1

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -4486,7 +4486,9 @@ class w2grid extends w2event {
                 if (child.w2ui.children == null) child.w2ui.children = []
             })
             this.records.splice.apply(this.records, [ind + 1, 0].concat(children))
-            this.total += children.length
+            if (this.total !== -1) {
+                this.total += children.length
+            }
             let url     = (typeof this.url != 'object' ? this.url : this.url.get)
             if (!url) {
                 this.localSort(true, true)
@@ -4573,7 +4575,9 @@ class w2grid extends w2event {
                 end++
             }
             this.records.splice(start, end - start + 1)
-            this.total -= end - start + 1
+            if (this.total !== -1) {
+                this.total -= end - start + 1
+            }
             let url     = (typeof this.url != 'object' ? this.url : this.url.get)
             if (!url) {
                 if (this.searchData.length > 0) {
@@ -8570,11 +8574,11 @@ class w2grid extends w2event {
             </button>`
         }
         return w2utils.message.call(this, {
-                    box   : this.box,
-                    path  : 'w2ui.' + this.name,
-                    title : '.w2ui-grid-header:visible',
-                    body  : '.w2ui-grid-box'
-                }, options)
+            box   : this.box,
+            path  : 'w2ui.' + this.name,
+            title : '.w2ui-grid-header:visible',
+            body  : '.w2ui-grid-box'
+        }, options)
     }
 
     confirm(options) {


### PR DESCRIPTION
Collapsing / Expanding children should not modify grid.total if it's -1

Reason: if grid.total is intetionally set to -1 from the server or any other time in the code, it's probably done so on purpose, e.g. to trigger the reloading of data during grid.scroll

By changing grid.total, this purposely set value is overriden.

And it's even overwritten false. Even if we only have 1 record with 3 children, when grid.total was initially -1, then adding 3 will result in grid.total becoming 2 (bit 1 + 3 is 4)

So no matter, it's a bad idea to change grid.total if it's -1