### PR TITLE
Grid fixes

### DIFF
--- a/demos/examples/combo/3.html
+++ b/demos/examples/combo/3.html
@@ -18,9 +18,9 @@
 <div id="main" style="width: 100%; height: 300px; margin-bottom: 10px;"></div>
 <button class="w2ui-btn" onclick="mark()">Mark Range C3:D7</button>
 <button class="w2ui-btn" onclick="w2ui.grid.removeRange('range')">Remove Range</button>
-&nbsp;&nbsp;&nbsp;
 <button class="w2ui-btn" onclick="cellFormat(true)">Cell Format</button>
 <button class="w2ui-btn" onclick="cellFormat(false)">Remove Cell Format</button>
+<button class="w2ui-btn" onclick="frozenToggle(['a', 'b', 'c'])">Toggle columns ABC frozen</button>
 
 <!--CODE-->
 <script>
@@ -114,5 +114,9 @@ function cellFormat(flag) {
     }
     w2ui.grid.refreshRow(rec1.recid);
     w2ui.grid.refreshRow(rec2.recid);
+}
+
+function frozenToggle(fields) {
+    w2ui.grid.updateColumn(fields, { frozen(col) { return !col.frozen } })
 }
 </script>

--- a/src/less/src/grid.less
+++ b/src/less/src/grid.less
@@ -505,7 +505,6 @@
 
             .w2ui-col-number {
                 width: 34px;
-                height: 26px;
                 color: @grid-row-number-color;
                 background-color: @grid-row-number-background-color;
                 div {

--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -1409,15 +1409,17 @@ class w2grid extends w2event {
                     $range.find('.w2ui-selection-resizer').hide()
                 }
                 if (first.recid != null && last.recid != null && td1f.length > 0 && td2f.length > 0) {
-                    sLeft = 0 // frozen columns do not need left offset
-                    sTop  = rec2.scrollTop()
-                    // work around jQuery inconsistency between vers >3.2 and <=3.3
-                    if (td1f.find('>div').position().top < 8) {
-                        sLeft = 0
-                        sTop  = 0
-                    }
-                    _left = (td1f.position().left - 0 + sLeft)
-                    _top  = (td1f.position().top - 0 + sTop)
+                    // sLeft = 0 // frozen columns do not need left offset
+                    // sTop  = rec2.scrollTop()
+                    // // work around jQuery inconsistency between vers >3.2 and <=3.3
+                    // if (td1f.find('>div').position().top < 8) {
+                    //     sLeft = 0
+                    //     sTop  = 0
+                    // }
+                    // _left = (td1f.position().left - 0 + sLeft)
+                    // _top  = (td1f.position().top - 0 + sTop)
+                    _left  = (td1f.position().left + td1f.scrollLeft())
+                    _top  = (td1f.position().top - td1f.scrollTop())
                     $range.show().css({
                         left    : (_left > 0 ? _left : 0) + 'px',
                         top     : (_top > 0 ? _top : 0) + 'px',
@@ -1449,15 +1451,17 @@ class w2grid extends w2event {
                     $range.css('border-left', '0px')
                 }
                 if (first.recid != null && last.recid != null && td1.length > 0 && td2.length > 0) {
-                    sLeft = rec2.scrollLeft()
-                    sTop  = rec2.scrollTop()
-                    // work around jQuery inconsistency between vers >3.2 and <=3.3
-                    if (td2.find('>div').position().top < 8) {
-                        sLeft = 0
-                        sTop  = 0
-                    }
-                    _left = (td1.position().left - 0 + sLeft)
-                    _top  = (td1.position().top - 0 + sTop)
+                    // sLeft = rec2.scrollLeft()
+                    // sTop  = rec2.scrollTop()
+                    // // work around jQuery inconsistency between vers >3.2 and <=3.3
+                    // if (td2.find('>div').position().top < 8) {
+                    //     sLeft = 0
+                    //     sTop  = 0
+                    // }
+                    // _left = (td1.position().left - 0 + sLeft) // fails if scrolled right
+                    // _top  = (td1.position().top - 0 + sTop) // fails if scrolled down
+                    _left  = (td1.position().left + td1.scrollLeft())
+                    _top  = (td1.position().top - td1.scrollTop())
                     // console.log('top', td1.position().top, rec2.scrollTop(), td1.find('>div').position().top)
                     $range.show().css({
                         left    : (_left > 0 ? _left : 0) + 'px',
@@ -5516,6 +5520,12 @@ class w2grid extends w2event {
         }
 
         function mouseMove (event) {
+            if(!event.target.tagName) {
+                // element has no tagName - most likely the target is the #document itself
+                // this can happen is you click+drag and move the mouse out of the DOM area,
+                // e.g. into the browser's toolbar area
+                return
+            }
             let mv = obj.last.move
             if (!mv || ['select', 'select-column'].indexOf(mv.type) == -1) return
             mv.divX = (event.screenX - mv.x)


### PR DESCRIPTION
Removed CSS height from ``.w2ui-col-number`` - height should be determined by recordHeight which is set on the parent TR.

Exit early in ``mouseMove()`` if event.target has no tagName attribute

Fixed Excel-like grid selection

CAUTION: I do not know why the existing code was so complex. Maybe it was due to a different JQuery version? That's why the old code was commented out and not removed!

Please review these changes carefully!

Related issues: #1890 and #1964