### PR TITLE
fix form rendering when html is passed in options

### DIFF
--- a/src/w2form.js
+++ b/src/w2form.js
@@ -1900,7 +1900,7 @@ class w2form extends w2base {
             }
             this.box = box
         }
-        if (!this.isGenerated) return
+        if (!this.isGenerated && !this.formHTML) return
         if (!this.box) return
         // event before
         let edata = this.trigger('render', {  target: this.name, box: (box != null ? box : this.box) })


### PR DESCRIPTION
When formHTML is passed in options rendering currently fails as it returns too early because flag isGenerated ist not set. Adding a check to continue rendering when formHTML is present. See #2202.