### PR TITLE
fixing `w2grid.refreshRow` - fails when called `w2grid.set()` and there is only summary fields

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -4440,7 +4440,7 @@
                 $(tr1).replaceWith(rec_html[0]);
                 $(tr2).replaceWith(rec_html[1]);
                 // apply style to row if it was changed in render functions
-                var st = (this.records[ind].w2ui ? this.records[ind].w2ui.style : '');
+                var st = (this.records[ind] && this.records[ind].w2ui ? this.records[ind].w2ui.style : '');
                 if (typeof st == 'string') {
                     var tr1 = $(this.box).find('#grid_'+ this.name +'_frec_'+ w2utils.escapeId(recid));
                     var tr2 = $(this.box).find('#grid_'+ this.name +'_rec_'+ w2utils.escapeId(recid));


### PR DESCRIPTION
When we calling a `w2grid.set()` for summary record, and `w2grid.records` is empty, getting of `this.records[ind].w2ui` will cause an error, obviously

Here is a quick fix