### PR TITLE
w2form: check/checks: Fixed setValue() method for array argument

### DIFF
--- a/src/w2form.js
+++ b/src/w2form.js
@@ -438,7 +438,7 @@ class w2form extends w2base {
             }
             case 'check':
             case 'checks': {
-                value = (!Array.isArray(value) && value != null) ? [value] : []
+                value = (!Array.isArray(value) && value != null) ? [value] : value
                 value = value.map(val => val?.id ?? val) // convert if array of objects
                 let inputs = query(el).closest('div').find('input')
                 let items  = field.options.items

--- a/src/w2form.js
+++ b/src/w2form.js
@@ -438,7 +438,12 @@ class w2form extends w2base {
             }
             case 'check':
             case 'checks': {
-                value = (!Array.isArray(value) && value != null) ? [value] : value
+                if (!Array.isArray(value)) {
+                    if (value != null)
+                        value = [value]
+                    else
+                        value = []
+                }
                 value = value.map(val => val?.id ?? val) // convert if array of objects
                 let inputs = query(el).closest('div').find('input')
                 let items  = field.options.items


### PR DESCRIPTION
setValue() works faulty if an array argument of multiple values is provided
for checks to select multiple checkboxes at once. Instead of keeping
the provided array it was reset to [].