### PR TITLE
fix w2ui.js:2937 Uncaught TypeError

### DIFF
--- a/src/w2utils.js
+++ b/src/w2utils.js
@@ -2096,11 +2096,11 @@ class Utils {
                 if (typeof params == 'string') {
                     params = params.split('|').map(key => {
                         if (key === 'true') key = true
-                        if (key === 'false') key = false
-                        if (key === 'undefined') key = undefined
-                        if (key === 'null') key = null
-                        if (parseFloat(key) == key) key = parseFloat(key)
-                        if (['\'', '"', '`'].includes(key[0]) && ['\'', '"', '`'].includes(key[key.length-1])) {
+                        else if (key === 'false') key = false
+                        else if (key === 'undefined') key = undefined
+                        else if (key === 'null') key = null
+                        else if (parseFloat(key) == key) key = parseFloat(key)
+                        else if (['\'', '"', '`'].includes(key[0]) && ['\'', '"', '`'].includes(key[key.length-1])) {
                             key = key.substring(1, key.length-1)
                         }
                         return key


### PR DESCRIPTION
fixes: 

w2ui.js:2937 Uncaught TypeError: Cannot read properties of null (reading '0')
    at w2ui.js:2937:58
    at Array.map (<anonymous>)
    at w2ui.js:2931:48
    at Array.forEach (<anonymous>)
    at w2ui.js:2923:34
    at w2ui.js:648:45
    at Array.forEach (<anonymous>)
    at Query.each (w2ui.js:648:20)
    at Utils.bindEvents (w2ui.js:2921:25)
    at w2grid.refreshSearch (w2ui.js:15067:17)

The following example results in the error as soon as a search is done:
https://mike-seger.github.io/grid-experiments/w2ui/regression/001.html

The following example contains the fix and results in no error:
https://mike-seger.github.io/grid-experiments/w2ui/regression/001-fixed.html 