### PR TITLE
we should define var before usage

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -4366,6 +4366,7 @@ class w2grid extends w2base {
         if (this.selectType == 'row') {
             if (sel.indexOf(recid) == -1) this.click(recid)
         } else {
+            let selected
             // check if any selected sel in the right row/column
             for (let i = 0; i < sel.length; i++) {
                 if (sel[i].recid == recid || sel[i].column == column) selected = true


### PR DESCRIPTION
Hi, minor fix.
Problem happens when grid selection mode is configured as `cell` mode and we try to  open context menu.

![image](https://user-images.githubusercontent.com/1185266/210966534-cff0827f-f7bd-4ccf-8942-a44872c5cb60.png)
