### PR TITLE
Improved performance when scrolling through tables.

### DIFF
--- a/dist/w2ui.js
+++ b/dist/w2ui.js
@@ -16824,6 +16824,8 @@ class w2grid extends w2base {
             records.prop('scrollTop', this.last.scrollTop)
             records.prop('scrollLeft', this.last.scrollLeft)
         }
+        // Improved performance when scrolling through tables
+        columns.css('will-change', 'scroll-position');
     }
     getSearchesHTML() {
         let html = `

--- a/dist/w2ui.js
+++ b/dist/w2ui.js
@@ -16825,7 +16825,7 @@ class w2grid extends w2base {
             records.prop('scrollLeft', this.last.scrollLeft)
         }
         // Improved performance when scrolling through tables
-        columns.css('will-change', 'scroll-position');
+        columns.css('will-change', 'scroll-position')
     }
     getSearchesHTML() {
         let html = `

--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -6863,7 +6863,7 @@ class w2grid extends w2base {
             records.prop('scrollLeft', this.last.scrollLeft)
         }
         // Improved performance when scrolling through tables
-        columns.css('will-change', 'scroll-position');
+        columns.css('will-change', 'scroll-position')
     }
 
     getSearchesHTML() {

--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -6862,6 +6862,8 @@ class w2grid extends w2base {
             records.prop('scrollTop', this.last.scrollTop)
             records.prop('scrollLeft', this.last.scrollLeft)
         }
+        // Improved performance when scrolling through tables
+        columns.css('will-change', 'scroll-position');
     }
 
     getSearchesHTML() {


### PR DESCRIPTION
2.0 version of #2374.
The above technique should work equally well in modern browsers such as Google Chrome.

As an alternative to the `transform` used above, this time we use `will-change`, which is supported by modern browsers.
If will-change is available, this is a more appropriate approach.

However, it is said that there are risks in adopting will-change.
(This is true for GPU hacks in general)
https://developer.mozilla.org/en-US/docs/Web/CSS/will-change

I suspect that this code will not cause serious problems since it only applies the property to a small fraction of the elements, but I'll leave it to your judgment.
If you do not currently see any performance problems, you may not want to incorporate this merge.