### PR TITLE
When search field is list, we should display text

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -5076,6 +5076,12 @@ class w2grid extends w2base {
                 let display
                 if (Array.isArray(sd.value)) {
                     display = `<span class="grid-search-count">${sd.value.length}</span>`
+                } else if (sf && sf.type == 'list') {
+                    const sd_value = sd.value
+                    const sd_text = sd.text
+
+                    display = !!sd_text && sd_text !== sd_value ? `: ${sd_text}` : `: ${sd_value}`
+                    
                 } else {
                     display = `: ${sd.value}`
                 }

--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -5077,11 +5077,7 @@ class w2grid extends w2base {
                 if (Array.isArray(sd.value)) {
                     display = `<span class="grid-search-count">${sd.value.length}</span>`
                 } else if (sf && sf.type == 'list') {
-                    const sd_value = sd.value
-                    const sd_text = sd.text
-
-                    display = !!sd_text && sd_text !== sd_value ? `: ${sd_text}` : `: ${sd_value}`
-                    
+                    display = !!sd.text && sd.text !== sd.value ? `: ${sd.text}` : `: ${sd.value}`
                 } else {
                     display = `: ${sd.value}`
                 }


### PR DESCRIPTION
Hi there!
When the search field is a list, the text should be displayed, not the value (unless they match)