### PR TITLE
Fix inline editing for 'list' types in grid (fixes #2378).

### DIFF
--- a/demos/examples/grid/21.html
+++ b/demos/examples/grid/21.html
@@ -10,7 +10,7 @@
 </div>
 
 <!--CODE-->
-<div id="grid" style="width: 900px; height: 400px;"></div>
+<div id="grid" style="width: 1000px; height: 400px;"></div>
 <br>
 <label style="margin-left: 20px">
     <input type="checkbox" id="fixedsize" checked="checked" onclick="advanceOnEdit(this.checked)">
@@ -63,8 +63,8 @@ let grid = new w2grid({
         { field: 'time', text: 'time', size: '70px', sortable: true, resizable: true,
             editable: { type: 'time' }
         },
-        { field: 'list', text: 'list', size: '50%', sortable: true, resizable: true, hidden: true,
-            editable: { type: 'list', items: people, showAll: true },
+        { field: 'list', text: 'list', size: '100px', sortable: true, resizable: true, hidden1: true,
+            editable: { type: 'list', items: people, showAll: true, openOnFocus: true, align: 'left' },
             render: function (record, extra) {
                 return extra.value?.text || '';
             }

--- a/src/less/src/grid.less
+++ b/src/less/src/grid.less
@@ -655,7 +655,6 @@
         padding: 3.5px 2px 2px 2px !important;
 
         input {
-            position: relative;
             top: -1px;
             border: 0 !important;
             border-radius: 0 !important;
@@ -682,11 +681,6 @@
             white-space: pre;
             overflow: hidden;
             .user-select(text);
-        }
-
-        input.w2ui-select {
-            outline: none !important;
-            background: #fff;
         }
     }
 

--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -3155,8 +3155,8 @@ class w2grid extends w2base {
         let rec = this.records[index]
         let col = this.columns[column]
         let prefix = (col.frozen === true ? '_f' : '_')
-        if (['list', 'enum', 'file'].indexOf(edit.type) != -1) {
-            console.log('ERROR: input types "list", "enum" and "file" are not supported in inline editing.')
+        if (['enum', 'file'].indexOf(edit.type) != -1) {
+            console.log('ERROR: input types "enum" and "file" are not supported in inline editing.')
             return
         }
         // event before
@@ -3382,15 +3382,17 @@ class w2grid extends w2base {
         // save previous value
         if (input) input._prevValue = prevValue
         // focus and select
-        setTimeout(() => {
-            if (!this.last.inEditMode) return
-            if (input) {
-                input.focus()
-                clearTimeout(this.last.kbd_timer) // keep focus
-                input.resize = expand
-                expand(input)
-            }
-        }, 50)
+        if (edit.type != 'list') {
+            setTimeout(() => {
+                if (!this.last.inEditMode) return
+                if (input) {
+                    input.focus()
+                    clearTimeout(this.last.kbd_timer) // keep focus
+                    input.resize = expand
+                    expand(input)
+                }
+            }, 50)
+        }
         // event after
         edata.finish({ input })
         return
@@ -5041,7 +5043,7 @@ class w2grid extends w2base {
                 }
             }, 50)
         }
-        this.updateToolbar()
+        this.updateToolbar(this.last.selection)
         // event after
         edata.finish()
         this.resize()
@@ -7802,7 +7804,7 @@ class w2grid extends w2base {
         if (this.show.expandColumn) {
             let tmp_img = ''
             if (record.w2ui?.expanded === true) tmp_img = '-'; else tmp_img = '+'
-            if ((record.w2ui?.expanded == 'none' || !Array.isArray(record.w2ui.children) || !record.w2ui.children.length)) tmp_img = '+'
+            if ((record.w2ui?.expanded == 'none' || !Array.isArray(record.w2ui?.children) || !record.w2ui?.children.length)) tmp_img = '+'
             if (record.w2ui?.expanded == 'spinner') tmp_img = '<div class="w2ui-spinner" style="width: 16px; margin: -2px 2px;"></div>'
             rec_html1 +=
                     '<td id="grid_'+ this.name +'_cell_'+ ind +'_expand' + (summary ? '_s' : '') + '" class="w2ui-grid-data w2ui-col-expand">'+


### PR DESCRIPTION
Started using inline editing when I realized 'list' was unsupported. Some styling also needed to be changed to display it correctly, I've tested to make sure it doesn't break anything but let me know if there was a reason.

I also updated the grid demo (tab 21) to show off both combo and list.