### PR TITLE
W2Grid: Avoid an error when the grid is loaded while cursor is over a column as it is rendered

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -7281,7 +7281,7 @@ class w2grid extends w2base {
         w2tooltip.show({
             name: this.name + '-column-tooltip',
             anchor: $el.get(0),
-            html: item.tooltip,
+            html: item?.tooltip,
             position: pos,
         })
     }


### PR DESCRIPTION
Avoid an error when the grid is loaded while cursor is over a column as it is rendered

Proposed "fix" for issue #2399 