### PR TITLE
W2Grid: columnContextMenu doc and typo fix

### DIFF
--- a/docs/details/w2grid.columnContextMenu.html
+++ b/docs/details/w2grid.columnContextMenu.html
@@ -1,0 +1,54 @@
+Called when user right clicks on the column.
+
+<div class="definition">
+    columnContextMenu(field, [event])
+</div>
+
+<div class="arguments">
+    <table>
+    <tr>
+        <td>field</td>
+        <td><b>string</b>, column field name</td>
+    </tr>
+    <tr>
+        <td>event</td>
+        <td><b>object</b>, <i>optional</i>, DOM Event Object</td>
+    </tr>
+    </table>
+</div>
+Returns <i>undefined</i>.
+
+<h4>Description</h4>
+
+This method is called when user right clicks on the column. The method emits the
+<a class="method" href="w2grid.onColumnContextMenu">.onColumnContextMenu</a> event and by default open a menu with predefined items.
+
+<div style="height: 10px"></div>
+
+If you have grid defined in the following way:
+<textarea class="javascript">
+let grid = new w2grid({
+    name : 'grid',
+    columns: [
+        { field: 'recid', text: 'ID', size: '50px' },
+        { field: 'lname', text: 'Last Name', size: '30%' },
+        { field: 'fname', text: 'First Name', size: '30%' },
+        { field: 'email', text: 'Email', size: '40%' },
+        { field: 'sdate', text: 'Start Date', size: '120px' },
+        { field: 'sdate', text: 'End Date', size: '120px' }
+    ],
+    records: [
+        { recid: 1, fname: 'John', lname: 'doe', email: 'vitali@gmail.com', sdate: '1/3/2012' },
+        { recid: 2, fname: 'Stuart', lname: 'Motzart', email: 'jdoe@gmail.com', sdate: '2/4/2012' },
+        { recid: 3, fname: 'Jin', lname: 'Franson', email: '--', sdate: '4/23/2012' },
+        { recid: 4, fname: 'Susan', lname: 'Ottie', email: 'jdoe@gmail.com', sdate: '5/3/2012' },
+        { recid: 5, fname: 'Kelly', lname: 'Silver', email: 'jdoe@gmail.com', sdate: '4/3/2012' },
+        { recid: 6, fname: 'Francis', lname: 'Gatos', email: 'vitali@gmail.com', sdate: '2/5/2012' }
+    ]
+});
+</textarea>
+
+You can emulate click on the column by:
+<textarea class="javascript">
+w2ui.grid.columnContextMenu('fname');
+</textarea>

--- a/docs/details/w2grid.onColumnContextMenu.html
+++ b/docs/details/w2grid.onColumnContextMenu.html
@@ -1,0 +1,46 @@
+Called when user right clicks a column.
+
+<div class="definition">
+    onColumnContextMenu = function(event)
+</div>
+
+The normal behavior of the right click on a column is to open a menu with predefined items, it can be overwritten using this event.
+You can add event listener during the object creation:
+
+<textarea class="javascript">
+let grid = new w2grid({
+    name    : 'grid',
+    columns: [
+        { field: 'recid', text: 'ID', size: '50px' },
+        { field: 'lname', text: 'Last Name', size: '30%' },
+        { field: 'fname', text: 'First Name', size: '30%' },
+        { field: 'email', text: 'Email', size: '40%' },
+        { field: 'sdate', text: 'End Date', size: '120px' }
+    ],
+    records: [
+        { recid: 1, fname: 'John', lname: 'doe', email: 'vitali@gmail.com', sdate: '1/3/2012' },
+        { recid: 2, fname: 'Stuart', lname: 'Motzart', email: 'jdoe@gmail.com', sdate: '2/4/2012' },
+        { recid: 3, fname: 'Jin', lname: 'Franson', email: '--', sdate: '4/23/2012' },
+        { recid: 4, fname: 'Susan', lname: 'Ottie', email: 'jdoe@gmail.com', sdate: '5/3/2012' },
+        { recid: 5, fname: 'Kelly', lname: 'Silver', email: 'jdoe@gmail.com', sdate: '4/3/2012' },
+        { recid: 6, fname: 'Francis', lname: 'Gatos', email: 'vitali@gmail.com', sdate: '2/5/2012' }
+    ],
+    onColumnContextMenu: function(event) {
+        console.log(event);
+    }
+});
+</textarea>
+
+or after the object has been created:
+
+<textarea class="javascript">
+w2ui.grid.on('columnContextMenu', function(event) {
+    console.log(event);
+});
+</textarea>
+
+The event handler is called before the default action of the event is triggered. You can cancel the default action by calling
+<span class="method">event.preventDefault()</span>. To perform an action
+after the event is fully processed, define <span class="method">event.onComplete</span> function.
+<div style="height: 10px;"></div>
+See <a href="utils/events">events</a> page in utilities for more details.

--- a/docs/summary/w2grid-events.php
+++ b/docs/summary/w2grid-events.php
@@ -50,6 +50,13 @@
 </div>
 
 <div class="obj-property">
+    <a href="w2grid.onColumnContextMenu">onColumnContextMenu</a> <span>- function (event)</span>
+</div>
+<div class="obj-property-desc">
+    Called when user right clicks a column.
+</div>
+
+<div class="obj-property">
     <a href="w2grid.onColumnDblClick">onColumnDblClick</a> <span>- function (event)</span>
 </div>
 <div class="obj-property-desc">

--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -3734,7 +3734,7 @@ class w2grid extends w2base {
         edata.finish()
     }
 
-    conlumnContextMenu(field, event) {
+    columnContextMenu(field, event) {
         let edata = this.trigger('columnContextMenu', {target: this.name, field: field, originalEvent: event })
         if (edata.isCancelled === true) return
         if (this.show.columnMenu) {


### PR DESCRIPTION
Added documentation for columnContextMenu as [requested](https://github.com/vitmalina/w2ui/pull/2401#issuecomment-1522662849).
Fixed a typo in method name. (typo was breaking, sorry)