### PR TITLE
Show the server response message even if status is not 200 (w2grid)

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -2914,7 +2914,11 @@ class w2grid extends w2base {
             if (edata2.isCancelled === true) return
             // default behavior
             if (response.status && response.status != 200) {
-                self.error(response.status + ': ' + response.statusText)
+                response.json().then((data) => {
+                  self.error(response.status + ': ' + data.message ?? response.statusText)
+                }).catch(() => {
+                  self.error(response.status + ': ' + response.statusText)
+                })
             } else {
                 console.log('ERROR: Server communication failed.',
                     '\n   EXPECTED:', { total: 5, records: [{ recid: 1, field: 'value' }] },


### PR DESCRIPTION
w2Grid adjustment. If your server returns non 200 response with a custom message, show this message in the popup instead of generic HTTP status description.

As described [in the docs](https://w2ui.com/web/docs/1.5/grid#struct-response), the response structure may contain "message" field. This message only showed up if response is 200.

Now, instead of the popup with "409: Conflict" we will see "409: Custom message because of duplicates". The custom message will be shown only if presented.