### PR TITLE
fix: reorder the grid row to the last position

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -5908,7 +5908,7 @@ class w2grid extends w2base {
                 let tmp   = query(event.target).parents('tr')
                 let ind  = tmp.attr('index')
                 let recid = obj.records[ind]?.recid
-                if (recid == '-none-') recid = 'bottom'
+                if (recid == '-none-' || recid == null) recid = 'bottom'
                 if (recid != mv.from) {
                     // let row1 = query(obj.box).find('#grid_'+ obj.name + '_rec_'+ mv.recid)
                     let row2 = query(obj.box).find('#grid_'+ obj.name + '_rec_'+ recid)


### PR DESCRIPTION
This pull requests solves #2472 , which is about the comparison with the last row recid.
I kept the original '-none-' logic, but also included 'null' check.