### PR TITLE
fix: unselect sidebar node with id 0

### DIFF
--- a/src/w2sidebar.js
+++ b/src/w2sidebar.js
@@ -684,7 +684,7 @@ class w2sidebar extends w2base {
                 /**
                  * Single selection at a time
                  */
-                if (this.selected) this.unselect(this.selected)
+                if (this.selected != null) this.unselect(this.selected)
                 this.select(id)
                 // route processing
                 if (typeof nd.route == 'string') {


### PR DESCRIPTION
The node with id: 0 remained selected after a new selection was made. It was about if(selected){} condition, where if(0){} is considered as false.