### PR TITLE
Ensure original event is included in toolbar button event details

### DIFF
--- a/src/w2toolbar.js
+++ b/src/w2toolbar.js
@@ -820,7 +820,7 @@ class w2toolbar extends w2base {
                     <div id="tb_${this.name}_item_${item.id}" class="${classes.join(' ')} ${(item.class ? item.class : '')}"
                         style="${(item.hidden ? 'display: none' : '')} ${item.type == 'label' ? (item.style ?? '') : ''}"
                         ${!item.disabled
-                            ? `data-click='["click","${item.id}"]'
+                            ? `data-click='["click","${item.id}", "event"]'
                                data-mouseenter='["mouseAction", "event", "this", "Enter", "${item.id}"]'
                                data-mouseleave='["mouseAction", "event", "this", "Leave", "${item.id}"]'
                                data-mousedown='["mouseAction", "event", "this", "Down", "${item.id}"]'


### PR DESCRIPTION
Let me know if I should open up an issue first, but for such a small change I figured I could just go ahead and create a PR. I noticed this with grid toolbars, but obviously the toolbar is a separate object.

If you debug the `onClick()` for toolbar buttons (built-in or custom) the `event.detail.originalEvent` property is `undefined`. I needed the event property to get the PointerEvent object to see if the `ctrlKey` property was True (whether the user was pressing the control key on the keyboard, so I can open the link in a new tab). Looking at how `w2utils.bindEvents()` works I figured out I just needed to add the "event" string to the data-click attribute list. This seems to fix it.
I don't know if this affects anything else, and I noticed that if the `item.id` is after the new `event` string the grid breaks and fails to initialize (no errors to the console though so I don't know what happened, I switched them and it worked so I didn't dig deeper).