### PR TITLE
BUGFIX Violation (non-passive event listener)

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -381,6 +381,9 @@ class Query {
             }
             this.each(node => {
                 this._save(node, 'events', [{ event, scope, callback, options }])
+                // fix "[Violation] Added non-passive event listener to a scroll-blocking 'mousewheel' event"
+                options = options || {}
+                options["passive"] = true
                 node.addEventListener(event, callback, options)
             })
         })


### PR DESCRIPTION
Fixed but that was resulting as console log warning while initializing grid element.

```
[Violation] Added non-passive event listener to a scroll-blocking 'mousewheel' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952
```
