### PR TITLE
unlock grid after reading the response

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -2955,12 +2955,12 @@ class w2grid extends w2base {
                     processError(resp ?? {})
                     return
                 }
-                self.unlock()
                 resp.json()
                     .catch(processError)
                     .then(data => {
                         this.requestComplete(data, action, callBack, resolve, reject)
                     })
+                    .finally(() => self.unlock())
             })
         if (action == 'load') {
             // event after


### PR DESCRIPTION
Grid unlocks immediately after receiving the response object, but before completing the stream reading.
This PR moves `.unlock()` call to the `rest.json().finally` statement.