### PR TITLE
Fix grid search marker replacing matches within title attribute.

### DIFF
--- a/src/w2utils.js
+++ b/src/w2utils.js
@@ -1594,7 +1594,8 @@ class Utils {
                 .replace(/</g, '&gt;')
                 .replace(/>/g, '&lt;')
             // only outside tags
-            let regex = new RegExp((ww ? '\\b' : '') + term + (ww ? '\\b' : '')+ '(?!([^<]+)?>)', 'i' + (!options.onlyFirst ? 'g' : ''))
+            // and only outside of quotes
+            let regex = new RegExp((ww ? '\\b' : '') + term + (ww ? '\\b' : '') + '(?=([a-z-0-9]+="[^"]*")*?[^"]+$)' + '(?!([^<]+)?>)', 'i' + (!options.onlyFirst ? 'g' : ''))
             return html = html.replace(regex, replaceWith)
         }
 


### PR DESCRIPTION
This fixes #2490 by adding a lookahead assertion to the replacement regex when adding in the `<span class="w2ui-marker"></span>` element to highlight specific words from a search in a grid.

The regex is a bit convoluted, but I found the answer on [Stack Overflow](https://stackoverflow.com/a/6464500), and you can play with an example of the regex [here](https://regex101.com/r/DLv3Yo/1) on regex101.

It really only applies to the `title=""` attribute, but I made it just capture any kind of attribute quoting to make sure it doesn't break on other inputs.