### PR TITLE
Fix incorrect cleaning of numeric fields

### DIFF
--- a/src/w2field.js
+++ b/src/w2field.js
@@ -824,7 +824,7 @@ class w2field extends w2base {
                     }
                 }
                 val = val.replace(/\s+/g, '')
-                         .replace(new RegExp(options.groupSymbol, 'g'), '')
+                         .replace(options.groupSymbol, '')
                          .replace(options.decimalSymbol, '.')
             }
             if (val !== '' && w2utils.isFloat(val)) val = Number(val); else val = ''


### PR DESCRIPTION
The `groupSymbol` was being used literally in a regular expression, but in various locales it is the character `.` which is the character wildcard.

The result was that the field was immediately cleared upon blur.