### PR TITLE
Also remove files from input element for w2field file types.

### DIFF
--- a/src/w2field.js
+++ b/src/w2field.js
@@ -636,6 +636,13 @@ class w2field extends w2base {
                         this.selected.splice(index, 1)
                         query(this.el).trigger('input').trigger('change')
                         query(event.target).remove()
+                        // remove file from input element
+                        let transfer = new DataTransfer()
+                        let input = query(event.target.previousElementSibling).find('input.file-input').get(0)
+                        Array.from(input.files)
+                            .filter(f => f.name != item.name)
+                            .forEach(f => transfer.items.add(f))
+                        input.files = transfer.files
                     } else {
                         // trigger event
                         edata = this.trigger('click', { target: this.el, originalEvent: event.originalEvent, item })


### PR DESCRIPTION
I noticed you aren't able to re-add files that were previously selected when using the file field type. This is because the input element still technically has the selected file in its store, so adding it again doesn't "change" anything (and the listener event that is used is "change.drag").

The `FileList` for an input element isn't editable, so to remove a specific item you need to convert it to an array, remove the item, and then create a `DataTranser` object and update its `files` property, which is a `FileList`, and then you can overwrite the `FileList` for the input element. Let me know if anything needs to be changed to follow the coding standard, etc.