### PR TITLE
Update w2grid.js to fix editable function

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -8474,10 +8474,10 @@ class w2grid extends w2base {
         if (edit === false) return null
         if (edit == null || edit === true) {
             edit = (Object.keys(col.editable ?? {}).length > 0 ? col.editable : null)
-            if (typeof edit === 'function') {
+            if (typeof col.editable === 'function') {
                 let value = this.getCellValue(ind, col_ind, false)
                 // same arguments as col.render()
-                edit = edit.call(this, rec, { self: this, value, index: ind, colIndex: col_ind })
+                edit = col.editable.call(this, rec, { self: this, value, index: ind, colIndex: col_ind })
             }
         }
         return edit


### PR DESCRIPTION
Short description
editable: function(record, extra) doesn't work.

What is current behavior
editable only works with object, not function.

in w2grid.js:
8476 edit = (Object.keys(col.editable ?? {}).length > 0 ? col.editable : null)
8477 if (typeof edit === 'function') {
8478 let value = this.getCellValue(ind, col_ind, false)
8479 // same arguments as col.render()
8480 edit = edit.call(this, rec, { self: this, value, index: ind, colIndex: col_ind })
8481 }

solution: 8477 and 8480, change edit to col.editable, it will work for editable when it is function.
also, many thanks to vitmalina for this great product.

8477 if (typeof col.editable === 'function') {
8478 let value = this.getCellValue(ind, col_ind, false)
8479 // same arguments as col.render()
8480 edit = col.editable.call(this, rec, { self: this, value, index: ind, colIndex: col_ind })
8481 }