### PR TITLE
w2grid-props.php: vs_extra: Update default and clarify wording

### DIFF
--- a/docs/summary/w2grid-props.php
+++ b/docs/summary/w2grid-props.php
@@ -421,10 +421,10 @@
 </div>
 
 <div class="obj-property">
-    <a href="w2grid.vs_extra">vs_extra</a> <span>- Number, default = 15</span>
+    <a href="w2grid.vs_extra">vs_extra</a> <span>- Number, default = 5</span>
 </div>
 <div class="obj-property-desc">
-    Defines the number of extra records to display when virtualizing
+    Defines the number of extra records to render when virtualizing.
 </div>
 
 <div class="obj-property">


### PR DESCRIPTION
The default is 5 for some time now, since commit 25ed390b8e3e3 . Also, update description and replace "display" with "render". Clearly, when virtualizing, we still cannot "display" more records than the grid height allows, but we can (pre)render more than that (to facilitate scrolling).