### PR TITLE
w2grid.js: If sortMode callback is defined, let it make all decisions

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -978,12 +978,19 @@ class w2grid extends w2base {
             // if both objects are strictly equal, we're done
             if (aa === bb)
                 return 0
+            let dir = (direction.toLowerCase() === 'asc') ? 1 : -1
+
+            // if we have comparison callback, let it make all decisions,
+            // including how nulls sort
+            if (typeof sortMode == 'function') {
+                return sortMode(aa, bb) * dir
+            }
+
             // all nulls, empty and undefined on bottom
             if ((aa == null || aa === '') && (bb != null && bb !== ''))
                 return 1
             if ((aa != null && aa !== '') && (bb == null || bb === ''))
                 return -1
-            let dir = (direction.toLowerCase() === 'asc') ? 1 : -1
             // for different kind of objects, sort by object type
             if (typeof aa != typeof bb)
                 return (typeof aa > typeof bb) ? dir : -dir


### PR DESCRIPTION
Previously, this comparison callback was called too late, after applying various adhoc conversions. Chances, they wouldn't work as user want, only leading to confusion. So, as long as the comparison callback is defined, call it as soon, not as late, as possible. This includes letting it decide how null values are sorted, instead of hardcoding a particular behavior. Calling ASAP and skipping all conversions also saves CPU cycles in users' browsers.