### PR TITLE
w2grid.js: Let render callback to optionally return 'title' property

### DIFF
--- a/src/w2grid.js
+++ b/src/w2grid.js
@@ -8205,7 +8205,7 @@ class w2grid extends w2base {
         if (col == null) return ''
         let record  = (summary !== true ? this.records[ind] : this.summary[ind])
         // value, attr, style, className, divAttr
-        let { value, style, className, attr, divAttr } = this.getCellValue(ind, col_ind, summary, true)
+        let { value, style, className, attr, divAttr, title } = this.getCellValue(ind, col_ind, summary, true)
         let edit = (ind !== -1 ? this.getCellEditable(ind, col_ind) : '')
         let divStyle = 'max-height: '+ parseInt(this.recordHeight) +'px;' + (col.clipboardCopy ? 'margin-right: 20px' : '')
         let isChanged = !summary && record?.w2ui?.changes && record.w2ui.changes[col.field] != null
@@ -8277,7 +8277,8 @@ class w2grid extends w2base {
                             data-changeInd="${changeInd}" data-colInd="${col_ind}" ${data ? 'checked="checked"' : ''}>`
             infoBubble    = ''
         }
-        data = `<div style="${divStyle}" ${getTitle(data)} ${divAttr}>${infoBubble}${String(data)}</div>`
+        // if renderer returned title it will have priority
+        data = `<div style="${divStyle}" ${getTitle(data, title)} ${divAttr}>${infoBubble}${String(data)}</div>`
         if (data == null) data = ''
         // --> cell TD
         if (typeof col.render == 'string') {
@@ -8319,9 +8320,8 @@ class w2grid extends w2base {
         }
         return data
 
-        function getTitle(cellData){
-            let title
-            if (obj.show.recordTitles) {
+        function getTitle(cellData, title){
+            if (title === undefined && obj.show.recordTitles) {
                 if (col.title != null) {
                     if (typeof col.title == 'function') {
                         title = col.title.call(obj, record, { self: this, index: ind, colIndex: col_ind, summary: !!summary })
@@ -8488,6 +8488,7 @@ class w2grid extends w2base {
         let record = (summary !== true ? this.records[ind] : this.summary[ind])
         let value = this.parseField(record, col.field)
         let className = '', style = '', attr = '', divAttr = ''
+        let title
         // if change by inline editing
         if (record?.w2ui?.changes?.[col.field] != null) {
             value = record.w2ui.changes[col.field]
@@ -8536,6 +8537,8 @@ class w2grid extends w2base {
                     style = html.style ?? ''
                     className = html.class ?? ''
                     divAttr = html.divAttr ?? ''
+                    // pass undefined up
+                    title = html.title
                 } else {
                     value = String(html || '').trim()
                 }
@@ -8549,7 +8552,7 @@ class w2grid extends w2base {
             }
         }
         if (value == null) value = ''
-        return !extra ? value : { value, attr, style, className, divAttr }
+        return !extra ? value : { value, attr, style, className, divAttr, title }
     }
 
     getFooterHTML() {


### PR DESCRIPTION
Currently, the renderer can return a lot of properties related to cell. But if you think about it, 'title' (to be shown as a tooltip by browser) is just another such property. So, offloading title generation to another `title` callback doesn't have much sense, especially taking into account that rendered value and tooltip are oftentimes connected, so it's more efficient to generate them in one call, instead of making double work via two callback calls. Actually, it kind of possible to return title from renderer now, using divAttr property. But that kind of conflicts with existing `recordTitles` support, so requires ugly workarounds if both are desired.

So, this change gives well defined ordering, while retaining backward compatibility with existing `title` callback:

1. If the `render` callback returns `title` property, it has priority, and will be used regardless of `recordTitles` state. (Because if user defined custom render callback and returned title from it, then they want title to be rendered, period).
2. Otherwise existing title handling will be used.